### PR TITLE
fix: minor fixes in OfflineSignerAdapter

### DIFF
--- a/packages/core/src/signers/adapter.ts
+++ b/packages/core/src/signers/adapter.ts
@@ -41,7 +41,7 @@ export interface OfflineSignerConfig {
 /**
  * Adapter class to use a CosmJS OfflineSigner instance as a Signer instance.
  */
-export default class OfflineSignerAdapter extends Signer {
+export class OfflineSignerAdapter extends Signer {
   private readonly signer: OfflineSigner;
 
   private readonly _signMode: SigningMode | undefined;

--- a/packages/core/src/signers/adapter.ts
+++ b/packages/core/src/signers/adapter.ts
@@ -120,7 +120,7 @@ export class OfflineSignerAdapter extends Signer {
   static fromMnemonic(
     mode: SigningMode,
     mnemonic: string,
-    options?: OfflineSignerConfig
+    options?: Partial<OfflineSignerConfig>
   ): Promise<OfflineSignerAdapter> {
     if (mode === SigningMode.DIRECT) {
       return DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
@@ -147,7 +147,7 @@ export class OfflineSignerAdapter extends Signer {
   static generate(
     mode: SigningMode,
     length?: 12 | 15 | 18 | 21 | 24,
-    options?: OfflineSignerConfig
+    options?: Partial<OfflineSignerConfig>
   ): Promise<OfflineSignerAdapter> {
     if (mode === SigningMode.DIRECT) {
       return DirectSecp256k1HdWallet.generate(length, {


### PR DESCRIPTION
This PR fixes the following issues:
* Wrong export of `OfflineSignerAdapter`;
* Made `options` param of `fromMnemonic` and `generates` `Partial` to not force the user to provide all the fields of `OfflineSignerConfig`