### PR TITLE
build(ci): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+# Release workflow builds the binaries for a release, and then publishes them to NPM.
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Node 👷
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow --tags --force
+
+      - name: Install 🔨
+        run: yarn install --immutable
+
+      - name: Build 🔨
+        run: yarn build
+
+      - name: Create release 📜
+        run: yarn publish-latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description 
This PR adds the `release.yml` GitHub workflow so that each time a new tag is pushed, a new NPM release will be created automatically. 