### PR TITLE
feat: allow to Amino-encode messages using DesmosClient

### DIFF
--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -24,6 +24,7 @@ import {
 import { Tendermint34Client } from "@cosmjs/tendermint-rpc";
 import {
   AccountData,
+  AminoMsg,
   encodeSecp256k1Pubkey,
   makeSignDoc as makeSignDocAmino,
   StdSignDoc,
@@ -346,6 +347,14 @@ export class DesmosClient extends SigningCosmWasmClient {
         );
   }
 
+  /**
+   * Encode the given message objects into Amino messages.
+   * @param msgs: Messages to be encoded.
+   */
+  public encodeToAmino(msgs: readonly EncodeObject[]): AminoMsg[] {
+    return msgs.map((msg) => this.types.toAmino(msg));
+  }
+
   private async signTxAmino(
     signerAddress: string,
     messages: readonly EncodeObject[],
@@ -358,7 +367,7 @@ export class DesmosClient extends SigningCosmWasmClient {
     const signerAccount = await this.getAccountFromSigner(signerAddress);
 
     // Build the SignDoc
-    const msgs = messages.map((msg) => this.types.toAmino(msg));
+    const msgs = this.encodeToAmino(messages);
     const signDoc = makeSignDocAmino(
       msgs,
       fee,


### PR DESCRIPTION
## Description
This PR adds a utility method named `encodeToAmino` to the `DesmosClient` type allowing developers to easily Amino-encode a list of `EncodeObject` that they might have created. This can be particularly useful when you want to Amino-encode some messages to later use them somewhere else (e.g. sending them to a third party API). 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code