### PR TITLE
fix: fix wrong reports registry messages type urls

### DIFF
--- a/packages/core/src/aminomessages/reports/registry.ts
+++ b/packages/core/src/aminomessages/reports/registry.ts
@@ -10,10 +10,7 @@ import {
 export const reportsRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   ["/desmos.reports.v1.MsgCreateReport", MsgCreateReport],
   ["/desmos.reports.v1.MsgDeleteReport", MsgDeleteReport],
-  [
-    "/desmos.reports.v1.MsgSupportStandardReason",
-    MsgSupportStandardReason,
-  ],
+  ["/desmos.reports.v1.MsgSupportStandardReason", MsgSupportStandardReason],
   ["/desmos.reports.v1.MsgAddReason", MsgAddReason],
   ["/desmos.reports.v1.MsgRemoveReason", MsgRemoveReason],
 ];

--- a/packages/core/src/aminomessages/reports/registry.ts
+++ b/packages/core/src/aminomessages/reports/registry.ts
@@ -8,14 +8,14 @@ import {
 } from "@desmoslabs/desmjs-types/desmos/reports/v1/msgs";
 
 export const reportsRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
-  ["/desmos.reports.v1.AminoMsgCreateReport", MsgCreateReport],
-  ["/desmos.reports.v1.AminoMsgDeleteReport", MsgDeleteReport],
+  ["/desmos.reports.v1.MsgCreateReport", MsgCreateReport],
+  ["/desmos.reports.v1.MsgDeleteReport", MsgDeleteReport],
   [
-    "/desmos.reports.v1.AminoMsgSupportStandardReason",
+    "/desmos.reports.v1.MsgSupportStandardReason",
     MsgSupportStandardReason,
   ],
-  ["/desmos.reports.v1.AminoMsgAddReason", MsgAddReason],
-  ["/desmos.reports.v1.AminoMsgRemoveReason", MsgRemoveReason],
+  ["/desmos.reports.v1.MsgAddReason", MsgAddReason],
+  ["/desmos.reports.v1.MsgRemoveReason", MsgRemoveReason],
 ];
 
 export default reportsRegistryTypes;


### PR DESCRIPTION
## Description

This PR fixes incorrect Reports module `reportsRegistryTypes` values.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
