### PR TITLE
Revert "build(deps): bump @cosmjs/crypto from 0.29.3 to 0.29.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.29.3",
-    "@cosmjs/crypto": "^0.29.4",
+    "@cosmjs/crypto": "^0.29.3",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/proto-signing": "^0.29.4",
     "@cosmjs/utils": "^0.29.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cosmjs/amino": "^0.29.4",
     "@cosmjs/cosmwasm-stargate": "^0.29.3",
-    "@cosmjs/crypto": "^0.29.4",
+    "@cosmjs/crypto": "^0.29.3",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/math": "^0.29.3",
     "@cosmjs/proto-signing": "^0.29.4",

--- a/packages/keplr/package.json
+++ b/packages/keplr/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@cosmjs/amino": "^0.29.4",
-    "@cosmjs/crypto": "^0.29.4",
+    "@cosmjs/crypto": "^0.29.3",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/math": "^0.29.3",
     "@cosmjs/proto-signing": "^0.29.4",

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@cosmjs/amino": "^0.29.4",
-    "@cosmjs/crypto": "^0.29.4",
+    "@cosmjs/crypto": "^0.29.3",
     "@cosmjs/encoding": "^0.29.4",
     "@cosmjs/math": "^0.29.3",
     "@cosmjs/proto-signing": "^0.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,7 +1808,7 @@ __metadata:
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.18.6
     "@cosmjs/amino": ^0.29.4
-    "@cosmjs/crypto": ^0.29.4
+    "@cosmjs/crypto": ^0.29.3
     "@cosmjs/encoding": ^0.29.4
     "@cosmjs/math": ^0.29.3
     "@cosmjs/proto-signing": ^0.29.4
@@ -1854,7 +1854,7 @@ __metadata:
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.18.6
     "@cosmjs/amino": ^0.29.4
-    "@cosmjs/crypto": ^0.29.4
+    "@cosmjs/crypto": ^0.29.3
     "@cosmjs/encoding": ^0.29.4
     "@cosmjs/math": ^0.29.3
     "@cosmjs/proto-signing": ^0.29.4
@@ -1890,7 +1890,7 @@ __metadata:
     "@babel/preset-typescript": ^7.18.6
     "@cosmjs/amino": ^0.29.4
     "@cosmjs/cosmwasm-stargate": ^0.29.3
-    "@cosmjs/crypto": ^0.29.4
+    "@cosmjs/crypto": ^0.29.3
     "@cosmjs/encoding": ^0.29.4
     "@cosmjs/math": ^0.29.3
     "@cosmjs/proto-signing": ^0.29.4
@@ -4222,7 +4222,7 @@ __metadata:
   resolution: "desmjs-monorepo-root@workspace:."
   dependencies:
     "@cosmjs/cosmwasm-stargate": ^0.29.3
-    "@cosmjs/crypto": ^0.29.4
+    "@cosmjs/crypto": ^0.29.3
     "@cosmjs/encoding": ^0.29.4
     "@cosmjs/proto-signing": ^0.29.4
     "@cosmjs/utils": ^0.29.4


### PR DESCRIPTION
Reverts desmos-labs/desmjs#95
This deps bumping does not pass the ci check.