### PR TITLE
feat: allow to provide a custom prefix in PrivateKeySigner.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node 👷
         uses: actions/setup-node@v3

--- a/packages/core/src/signers/privatekey.ts
+++ b/packages/core/src/signers/privatekey.ts
@@ -31,6 +31,9 @@ export enum PrivateKeyType {
   Secp256k1,
 }
 
+/**
+ * Interface representing a private key.
+ */
 export interface PrivateKey {
   type: PrivateKeyType;
   key: Uint8Array;
@@ -139,10 +142,6 @@ export class Secp256k1KeyProvider extends PrivateKeyProvider {
  */
 export interface PrivateKeySignerOptions {
   /**
-   * Signer signing mode.
-   */
-  signMode: SigningMode;
-  /**
    * Prefix used to generate the bech32 address.
    */
   prefix?: string;
@@ -188,20 +187,30 @@ export class PrivateKeySigner extends Signer {
   /**
    * Build the signer from a secp256k1 private key.
    * @param privateKey - Hex encoded private key, or raw private key bytes.
+   * @param signingMode - Hex encoded private key, or raw private key bytes.
    * @param options - Signer options.
    */
   static fromSecp256k1(
     privateKey: string | Uint8Array,
-    options: PrivateKeySignerOptions
+    signingMode: SigningMode,
+    options?: PrivateKeySignerOptions
   ): PrivateKeySigner {
-    return new PrivateKeySigner(new Secp256k1KeyProvider(privateKey), options);
+    return new PrivateKeySigner(
+      new Secp256k1KeyProvider(privateKey),
+      signingMode,
+      options
+    );
   }
 
-  constructor(provider: PrivateKeyProvider, options: PrivateKeySignerOptions) {
+  constructor(
+    provider: PrivateKeyProvider,
+    signingMode: SigningMode,
+    options?: PrivateKeySignerOptions
+  ) {
     super(PrivateKeySigner.keyProviderStatusToSignerStatus(provider.status));
     this.keyProvider = provider;
     this.keyProvider.addStatusListener(this.keyProviderStatusListener);
-    this.signMode = options.signMode;
+    this.signMode = signingMode;
     this.prefix = options?.prefix ?? "desmos";
   }
 

--- a/packages/core/src/signers/privatekey.unit.spec.ts
+++ b/packages/core/src/signers/privatekey.unit.spec.ts
@@ -83,7 +83,7 @@ describe("PrivateKeySigner", () => {
   it("Fail to connect to key provider", async () => {
     const signer = new PrivateKeySigner(
       mockConnectFailingSecp256k1KeyProvider(),
-      SigningMode.DIRECT
+      { signMode: SigningMode.DIRECT }
     );
     await expect(signer.connect()).rejects.toHaveProperty(
       "message",
@@ -95,7 +95,7 @@ describe("PrivateKeySigner", () => {
   it("Fail to get private key", async () => {
     const signer = new PrivateKeySigner(
       mockFailingGetPrivateKeySecp256k1KeyProvider(),
-      SigningMode.DIRECT
+      { signMode: SigningMode.DIRECT }
     );
     await expect(signer.connect()).rejects.toHaveProperty(
       "message",
@@ -105,10 +105,9 @@ describe("PrivateKeySigner", () => {
   });
 
   it("connect successfully", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.DIRECT
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.DIRECT,
+    });
     await signer.connect();
     expect(signer.status).toBe(SignerStatus.Connected);
     const accounts = await signer.getAccounts();
@@ -118,7 +117,7 @@ describe("PrivateKeySigner", () => {
   it("disconnect fail", async () => {
     const signer = new PrivateKeySigner(
       mockDisconnectFailingSecp256k1KeyProvider(),
-      SigningMode.DIRECT
+      { signMode: SigningMode.DIRECT }
     );
     await signer.connect();
     await expect(signer.disconnect()).rejects.toHaveProperty(
@@ -129,20 +128,18 @@ describe("PrivateKeySigner", () => {
   });
 
   it("disconnect successfully", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.DIRECT
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.DIRECT,
+    });
     await signer.connect();
     await signer.disconnect();
     expect(signer.status).toBe(SignerStatus.NotConnected);
   });
 
   it("get current account successfully", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.DIRECT
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.DIRECT,
+    });
     await signer.connect();
     const accounts = await signer.getAccounts();
     const currentAccount = await signer.getCurrentAccount();
@@ -153,10 +150,9 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign direct successfully", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.DIRECT
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.DIRECT,
+    });
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     const signResult = await signer.signDirect(currentAccount!.address, {
@@ -183,10 +179,9 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign amino from direct error", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.DIRECT
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.DIRECT,
+    });
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     await expect(
@@ -205,10 +200,9 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign amino successfully", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.AMINO
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.AMINO,
+    });
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     const signResult = await signer.signAmino(currentAccount!.address, {
@@ -229,10 +223,9 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign direct from amino error", async () => {
-    const signer = new PrivateKeySigner(
-      mockSecp256k1KeyProvider(),
-      SigningMode.AMINO
-    );
+    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
+      signMode: SigningMode.AMINO,
+    });
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     await expect(

--- a/packages/core/src/signers/privatekey.unit.spec.ts
+++ b/packages/core/src/signers/privatekey.unit.spec.ts
@@ -83,7 +83,7 @@ describe("PrivateKeySigner", () => {
   it("Fail to connect to key provider", async () => {
     const signer = new PrivateKeySigner(
       mockConnectFailingSecp256k1KeyProvider(),
-      { signMode: SigningMode.DIRECT }
+      SigningMode.DIRECT
     );
     await expect(signer.connect()).rejects.toHaveProperty(
       "message",
@@ -95,7 +95,7 @@ describe("PrivateKeySigner", () => {
   it("Fail to get private key", async () => {
     const signer = new PrivateKeySigner(
       mockFailingGetPrivateKeySecp256k1KeyProvider(),
-      { signMode: SigningMode.DIRECT }
+      SigningMode.DIRECT
     );
     await expect(signer.connect()).rejects.toHaveProperty(
       "message",
@@ -105,9 +105,10 @@ describe("PrivateKeySigner", () => {
   });
 
   it("connect successfully", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.DIRECT,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.DIRECT
+    );
     await signer.connect();
     expect(signer.status).toBe(SignerStatus.Connected);
     const accounts = await signer.getAccounts();
@@ -117,7 +118,7 @@ describe("PrivateKeySigner", () => {
   it("disconnect fail", async () => {
     const signer = new PrivateKeySigner(
       mockDisconnectFailingSecp256k1KeyProvider(),
-      { signMode: SigningMode.DIRECT }
+      SigningMode.DIRECT
     );
     await signer.connect();
     await expect(signer.disconnect()).rejects.toHaveProperty(
@@ -128,18 +129,20 @@ describe("PrivateKeySigner", () => {
   });
 
   it("disconnect successfully", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.DIRECT,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.DIRECT
+    );
     await signer.connect();
     await signer.disconnect();
     expect(signer.status).toBe(SignerStatus.NotConnected);
   });
 
   it("get current account successfully", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.DIRECT,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.DIRECT
+    );
     await signer.connect();
     const accounts = await signer.getAccounts();
     const currentAccount = await signer.getCurrentAccount();
@@ -150,9 +153,10 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign direct successfully", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.DIRECT,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.DIRECT
+    );
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     const signResult = await signer.signDirect(currentAccount!.address, {
@@ -179,9 +183,10 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign amino from direct error", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.DIRECT,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.DIRECT
+    );
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     await expect(
@@ -200,9 +205,10 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign amino successfully", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.AMINO,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.AMINO
+    );
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     const signResult = await signer.signAmino(currentAccount!.address, {
@@ -223,9 +229,10 @@ describe("PrivateKeySigner", () => {
   });
 
   it("sign direct from amino error", async () => {
-    const signer = new PrivateKeySigner(mockSecp256k1KeyProvider(), {
-      signMode: SigningMode.AMINO,
-    });
+    const signer = new PrivateKeySigner(
+      mockSecp256k1KeyProvider(),
+      SigningMode.AMINO
+    );
     await signer.connect();
     const currentAccount = await signer.getCurrentAccount();
     await expect(

--- a/packages/web3auth-mobile/src/privatekeyprovider.ts
+++ b/packages/web3auth-mobile/src/privatekeyprovider.ts
@@ -2,10 +2,7 @@ import {
   PrivateKey,
   PrivateKeyProvider,
   PrivateKeyProviderStatus,
-  PrivateKeySigner,
   PrivateKeyType,
-  Signer,
-  PrivateKeySignerOptions,
 } from "@desmoslabs/desmjs";
 import Web3Auth, {
   SdkLoginParams,
@@ -96,21 +93,4 @@ export class Web3AuthKeyProvider extends PrivateKeyProvider {
 
     return this.privateKey;
   }
-}
-
-/**
- * Gets a Signer instance capable of signing transactions using the key received from Web3Auth.
- * @param signerOptions - The signer options.
- * @param web3auth - Web3Auth client.
- * @param params - Web3Auth params.
- */
-export function web3authSigner(
-  signerOptions: PrivateKeySignerOptions,
-  web3auth: Web3Auth,
-  params: Web3AuthKeyProviderParams
-): Signer {
-  return new PrivateKeySigner(
-    new Web3AuthKeyProvider(web3auth, params),
-    signerOptions
-  );
 }

--- a/packages/web3auth-mobile/src/privatekeyprovider.ts
+++ b/packages/web3auth-mobile/src/privatekeyprovider.ts
@@ -5,7 +5,7 @@ import {
   PrivateKeySigner,
   PrivateKeyType,
   Signer,
-  SigningMode,
+  PrivateKeySignerOptions,
 } from "@desmoslabs/desmjs";
 import Web3Auth, {
   SdkLoginParams,
@@ -100,17 +100,17 @@ export class Web3AuthKeyProvider extends PrivateKeyProvider {
 
 /**
  * Gets a Signer instance capable of signing transactions using the key received from Web3Auth.
- * @param signingMode - The Signer signing mode.
+ * @param signerOptions - The signer options.
  * @param web3auth - Web3Auth client.
  * @param params - Web3Auth params.
  */
 export function web3authSigner(
-  signingMode: SigningMode,
+  signerOptions: PrivateKeySignerOptions,
   web3auth: Web3Auth,
   params: Web3AuthKeyProviderParams
 ): Signer {
   return new PrivateKeySigner(
     new Web3AuthKeyProvider(web3auth, params),
-    signingMode
+    signerOptions
   );
 }

--- a/packages/web3auth-web/src/privatekeyprovider.ts
+++ b/packages/web3auth-web/src/privatekeyprovider.ts
@@ -3,9 +3,7 @@ import {
   PrivateKey,
   PrivateKeyProvider,
   PrivateKeyProviderStatus,
-  PrivateKeySigner,
   PrivateKeyType,
-  PrivateKeySignerOptions,
 } from "@desmoslabs/desmjs";
 import { fromHex } from "@cosmjs/encoding";
 import { ADAPTER_EVENTS, WALLET_ADAPTER_TYPE } from "@web3auth/base";
@@ -114,21 +112,4 @@ export class Web3AuthPrivateKeyProvider extends PrivateKeyProvider {
 
     this.updateStatus(PrivateKeyProviderStatus.NotConnected);
   }
-}
-
-/**
- * Gets a Signer instance capable of sign transaction using the key received from Web3Auth.
- * @param signerOptions - The Signer options.
- * @param web3auth - Web3Auth client.
- * @param options - Extra Web3Auth options.
- */
-export function web3AuthSigner(
-  signerOptions: PrivateKeySignerOptions,
-  web3auth: Web3Auth,
-  options?: Web3AuthPrivateKeyProviderOptions
-): PrivateKeySigner {
-  return new PrivateKeySigner(
-    new Web3AuthPrivateKeyProvider(web3auth, options),
-    signerOptions
-  );
 }

--- a/packages/web3auth-web/src/privatekeyprovider.ts
+++ b/packages/web3auth-web/src/privatekeyprovider.ts
@@ -5,7 +5,7 @@ import {
   PrivateKeyProviderStatus,
   PrivateKeySigner,
   PrivateKeyType,
-  SigningMode,
+  PrivateKeySignerOptions,
 } from "@desmoslabs/desmjs";
 import { fromHex } from "@cosmjs/encoding";
 import { ADAPTER_EVENTS, WALLET_ADAPTER_TYPE } from "@web3auth/base";
@@ -118,17 +118,17 @@ export class Web3AuthPrivateKeyProvider extends PrivateKeyProvider {
 
 /**
  * Gets a Signer instance capable of sign transaction using the key received from Web3Auth.
- * @param signingMode - The Signer signing mode.
+ * @param signerOptions - The Signer options.
  * @param web3auth - Web3Auth client.
  * @param options - Extra Web3Auth options.
  */
 export function web3AuthSigner(
-  signingMode: SigningMode,
+  signerOptions: PrivateKeySignerOptions,
   web3auth: Web3Auth,
   options?: Web3AuthPrivateKeyProviderOptions
 ): PrivateKeySigner {
   return new PrivateKeySigner(
     new Web3AuthPrivateKeyProvider(web3auth, options),
-    signingMode
+    signerOptions
   );
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR implements the possibility to provide a custom bech32  address prefix for the `PrivateKeySigner`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
