### PR TITLE
feat: use the proto/amino type consts instead of strings

### DIFF
--- a/packages/core/src/aminomessages/cosmos/authz/authorizations.ts
+++ b/packages/core/src/aminomessages/cosmos/authz/authorizations.ts
@@ -3,7 +3,10 @@ import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
 import { AminoConverters } from "@cosmjs/stargate";
 import { Any } from "cosmjs-types/google/protobuf/any";
 import { AminoGenericAuthorization } from "./messages";
-import { GenericAuthorizationTypeUrl } from "../../../const";
+import {
+  GenericAuthorizationAminoType,
+  GenericAuthorizationTypeUrl,
+} from "../../../const";
 
 export function genericAuthorizationToAny(
   authorization: GenericAuthorization
@@ -16,8 +19,8 @@ export function genericAuthorizationToAny(
 
 export function createAuthzAuthorizationConverters(): AminoConverters {
   return {
-    "/cosmos.authz.v1beta1.GenericAuthorization": {
-      aminoType: "cosmos-sdk/GenericAuthorization",
+    [GenericAuthorizationTypeUrl]: {
+      aminoType: GenericAuthorizationAminoType,
       toAmino: (
         authorization: Any["value"]
       ): AminoGenericAuthorization["value"] => {

--- a/packages/core/src/aminomessages/cosmos/authz/converter.ts
+++ b/packages/core/src/aminomessages/cosmos/authz/converter.ts
@@ -8,6 +8,12 @@ import { createAuthzAuthorizationConverters } from "./authorizations";
 import { createBankAuthorizationConverters } from "../bank";
 import { createSubspacesAuthorizationConverters } from "../../subspaces";
 import { createStakeAuthorizationConverters } from "../staking";
+import {
+  MsgGrantAminoTpe,
+  MsgGrantTypeUrl,
+  MsgRevokeAminoType,
+  MsgRevokeTypeUrl,
+} from "../../../const";
 
 const authorizationTypes = new AminoTypes({
   ...createAuthzAuthorizationConverters(),
@@ -54,8 +60,8 @@ function convertAminoGrant(grant: AminoGrant): Grant {
 export function createAuthzConverters(): AminoConverters {
   return {
     // Authz types
-    "/cosmos.authz.v1beta1.MsgGrant": {
-      aminoType: "cosmos-sdk/MsgGrant",
+    [MsgGrantTypeUrl]: {
+      aminoType: MsgGrantAminoTpe,
       toAmino: (value: MsgGrant): AminoMsgGrant["value"] => ({
         grant: value.grant ? convertGrant(value.grant) : undefined,
         granter: value.granter,
@@ -68,8 +74,8 @@ export function createAuthzConverters(): AminoConverters {
           grantee: msg.grantee,
         }),
     },
-    "/cosmos.authz.v1beta1.MsgRevoke": {
-      aminoType: "cosmos-sdk/MsgRevoke",
+    [MsgRevokeTypeUrl]: {
+      aminoType: MsgRevokeAminoType,
       toAmino: (value: MsgRevoke): AminoMsgRevoke["value"] => ({
         granter: value.granter,
         grantee: value.grantee,

--- a/packages/core/src/aminomessages/cosmos/authz/messages.ts
+++ b/packages/core/src/aminomessages/cosmos/authz/messages.ts
@@ -1,7 +1,12 @@
 import { AminoMsg } from "@cosmjs/amino";
+import {
+  GenericAuthorizationAminoType,
+  MsgGrantAminoTpe,
+  MsgRevokeAminoType,
+} from "../../../const";
 
 export interface AminoGenericAuthorization extends AminoMsg {
-  readonly type: "cosmos-sdk/GenericAuthorization";
+  readonly type: typeof GenericAuthorizationAminoType;
   readonly value: {
     readonly msg: string;
   };
@@ -13,7 +18,7 @@ export interface AminoGrant {
 }
 
 export interface AminoMsgGrant extends AminoMsg {
-  readonly type: "cosmos-sdk/MsgGrant";
+  readonly type: typeof MsgGrantAminoTpe;
   readonly value: {
     readonly grant?: AminoGrant;
     readonly grantee: string;
@@ -22,7 +27,7 @@ export interface AminoMsgGrant extends AminoMsg {
 }
 
 export interface AminoMsgRevoke extends AminoMsg {
-  readonly type: "cosmos-sdk/MsgRevoke";
+  readonly type: typeof MsgRevokeAminoType;
   readonly value: {
     readonly grantee: string;
     readonly granter: string;

--- a/packages/core/src/aminomessages/cosmos/bank/authorizations.ts
+++ b/packages/core/src/aminomessages/cosmos/bank/authorizations.ts
@@ -2,7 +2,10 @@ import { AminoConverters } from "@cosmjs/stargate";
 import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
 import { Any } from "cosmjs-types/google/protobuf/any";
 import { AminoSendAuthorization } from "./messages";
-import { SendAuthorizationTypeUrl } from "../../../const";
+import {
+  SendAuthorizationAminoType,
+  SendAuthorizationTypeUrl,
+} from "../../../const";
 
 export function sendAuthorizationToAny(authorization: SendAuthorization): Any {
   return Any.fromPartial({
@@ -13,8 +16,8 @@ export function sendAuthorizationToAny(authorization: SendAuthorization): Any {
 
 export function createBankAuthorizationConverters(): AminoConverters {
   return {
-    "/cosmos.bank.v1beta1.SendAuthorization": {
-      aminoType: "cosmos-sdk/SendAuthorization",
+    [SendAuthorizationTypeUrl]: {
+      aminoType: SendAuthorizationAminoType,
       toAmino: (
         authorization: Any["value"]
       ): AminoSendAuthorization["value"] => {

--- a/packages/core/src/aminomessages/cosmos/bank/messages.ts
+++ b/packages/core/src/aminomessages/cosmos/bank/messages.ts
@@ -1,7 +1,8 @@
 import { AminoMsg, Coin } from "@cosmjs/amino";
+import { SendAuthorizationAminoType } from "../../../const";
 
 export interface AminoSendAuthorization extends AminoMsg {
-  readonly type: "cosmos-sdk/SendAuthorization";
+  readonly type: typeof SendAuthorizationAminoType;
   readonly value: {
     readonly spend_limit: Coin[];
   };

--- a/packages/core/src/aminomessages/cosmos/feegrant/converter.ts
+++ b/packages/core/src/aminomessages/cosmos/feegrant/converter.ts
@@ -14,18 +14,25 @@ import {
   AminoAllowedMsgAllowance,
   AminoBasicAllowance,
   AminoMsgGrantAllowance,
-  AminoPeriodicAllowance,
   AminoMsgRevokeAllowance,
+  AminoPeriodicAllowance,
 } from "./messages";
 import {
+  AllowedMsgAllowanceAminoType,
   AllowedMsgAllowanceTypeUrl,
+  BasicAllowanceAminoType,
   BasicAllowanceTypeUrl,
+  MsgGrantAllowanceAminoType,
+  MsgGrantAllowanceTypeUrl,
+  MsgRevokeAllowanceAminoType,
+  MsgRevokeAllowanceTypeUrl,
+  PeriodicAllowanceAminoType,
   PeriodicAllowanceTypeUrl,
 } from "../../../const";
 
 function basicAllowanceToAmino(value: BasicAllowance): AminoBasicAllowance {
   return {
-    type: "cosmos-sdk/BasicAllowance",
+    type: BasicAllowanceAminoType,
     value: {
       spend_limit: value.spendLimit,
       expiration: value.expiration,
@@ -46,7 +53,7 @@ function periodicAllowanceToAmino(
   value: PeriodicAllowance
 ): AminoPeriodicAllowance {
   return {
-    type: "cosmos-sdk/AminoPeriodicAllowance",
+    type: PeriodicAllowanceAminoType,
     value: {
       basic: value.basic ? basicAllowanceToAmino(value.basic) : undefined,
       period: value.period,
@@ -73,7 +80,7 @@ function allowedMsgAllowanceToAmino(
   value: AllowedMsgAllowance
 ): AminoAllowedMsgAllowance {
   return {
-    type: "cosmos-sdk/AminoAllowedMsgAllowance",
+    type: AllowedMsgAllowanceAminoType,
     value: {
       allowance: value.allowance
         ? allowanceToAmino(value.allowance)
@@ -110,7 +117,7 @@ function allowanceToAmino(any: Any): AminoMsg {
 
 function allowanceFromAmino(allowance: AminoMsg): Any {
   switch (allowance.type) {
-    case "cosmos-sdk/BasicAllowance":
+    case BasicAllowanceAminoType:
       return Any.fromPartial({
         typeUrl: BasicAllowanceTypeUrl,
         value: BasicAllowance.encode(
@@ -118,7 +125,7 @@ function allowanceFromAmino(allowance: AminoMsg): Any {
         ).finish(),
       });
 
-    case "cosmos-sdk/PeriodicAllowance":
+    case PeriodicAllowanceAminoType:
       return Any.fromPartial({
         typeUrl: PeriodicAllowanceTypeUrl,
         value: PeriodicAllowance.encode(
@@ -126,7 +133,7 @@ function allowanceFromAmino(allowance: AminoMsg): Any {
         ).finish(),
       });
 
-    case "cosmos-sdk/AllowedMsgAllowance":
+    case AllowedMsgAllowanceAminoType:
       return Any.fromPartial({
         typeUrl: AllowedMsgAllowanceTypeUrl,
         value: PeriodicAllowance.encode(
@@ -141,21 +148,21 @@ function allowanceFromAmino(allowance: AminoMsg): Any {
 
 export function createFeegrantConverters(): AminoConverters {
   return {
-    "/cosmos.feegrant.v1beta1.BasicAllowance": {
-      aminoType: "cosmos-sdk/BasicAllowance",
+    [BasicAllowanceTypeUrl]: {
+      aminoType: BasicAllowanceAminoType,
       toAmino: (value: BasicAllowance): AminoBasicAllowance["value"] =>
         basicAllowanceToAmino(value).value,
       fromAmino: (value: AminoBasicAllowance["value"]) =>
         basicAllowanceFromAmino(value),
     },
-    "/cosmos.feegrant.v1beta1.PeriodicAllowance": {
-      aminoType: "cosmos-sdk/PeriodicAllowance",
+    [PeriodicAllowanceTypeUrl]: {
+      aminoType: PeriodicAllowanceAminoType,
       toAmino: (value: PeriodicAllowance): AminoPeriodicAllowance["value"] =>
         periodicAllowanceToAmino(value).value,
       fromAmino: periodicAllowanceFromAmino,
     },
-    "/cosmos.feegrant.v1beta1.AllowedMsgAllowance": {
-      aminoType: "cosmos-sdk/AllowedMsgAllowance",
+    [AllowedMsgAllowanceTypeUrl]: {
+      aminoType: AllowedMsgAllowanceAminoType,
       toAmino: (
         value: AllowedMsgAllowance
       ): AminoAllowedMsgAllowance["value"] =>
@@ -164,8 +171,8 @@ export function createFeegrantConverters(): AminoConverters {
         value: AminoAllowedMsgAllowance["value"]
       ): AllowedMsgAllowance => allowedMsgAllowanceFromAmino(value),
     },
-    "/cosmos.feegrant.v1beta1.MsgGrantAllowance": {
-      aminoType: "cosmos-sdk/MsgGrantAllowance",
+    [MsgGrantAllowanceTypeUrl]: {
+      aminoType: MsgGrantAllowanceAminoType,
       toAmino: (msg: MsgGrantAllowance): AminoMsgGrantAllowance["value"] => ({
         allowance: msg.allowance ? allowanceToAmino(msg.allowance) : undefined,
         granter: msg.granter,
@@ -180,8 +187,8 @@ export function createFeegrantConverters(): AminoConverters {
             : undefined,
         }),
     },
-    "/cosmos.feegrant.v1beta1.MsgRevokeAllowance": {
-      aminoType: "cosmos-sdk/MsgRevokeAllowance",
+    [MsgRevokeAllowanceTypeUrl]: {
+      aminoType: MsgRevokeAllowanceAminoType,
       toAmino: (msg: MsgRevokeAllowance): AminoMsgRevokeAllowance["value"] => ({
         granter: msg.granter,
         grantee: msg.grantee,

--- a/packages/core/src/aminomessages/cosmos/feegrant/messages.ts
+++ b/packages/core/src/aminomessages/cosmos/feegrant/messages.ts
@@ -1,9 +1,16 @@
 import { AminoMsg, Coin } from "@cosmjs/amino";
 import { Timestamp } from "cosmjs-types/google/protobuf/timestamp";
 import { Duration } from "cosmjs-types/google/protobuf/duration";
+import {
+  AllowedMsgAllowanceAminoType,
+  BasicAllowanceAminoType,
+  MsgGrantAllowanceAminoType,
+  MsgRevokeAllowanceAminoType,
+  PeriodicAllowanceAminoType,
+} from "../../../const";
 
 export interface AminoBasicAllowance extends AminoMsg {
-  readonly type: "cosmos-sdk/BasicAllowance";
+  readonly type: typeof BasicAllowanceAminoType;
   readonly value: {
     spend_limit: Coin[];
     expiration?: Timestamp;
@@ -11,7 +18,7 @@ export interface AminoBasicAllowance extends AminoMsg {
 }
 
 export interface AminoPeriodicAllowance extends AminoMsg {
-  readonly type: "cosmos-sdk/AminoPeriodicAllowance";
+  readonly type: typeof PeriodicAllowanceAminoType;
   readonly value: {
     basic?: AminoBasicAllowance;
     period?: Duration;
@@ -22,7 +29,7 @@ export interface AminoPeriodicAllowance extends AminoMsg {
 }
 
 export interface AminoAllowedMsgAllowance extends AminoMsg {
-  readonly type: "cosmos-sdk/AminoAllowedMsgAllowance";
+  readonly type: typeof AllowedMsgAllowanceAminoType;
   readonly value: {
     allowance?: AminoMsg;
     allowed_messages: string[];
@@ -30,7 +37,7 @@ export interface AminoAllowedMsgAllowance extends AminoMsg {
 }
 
 export interface AminoMsgGrantAllowance extends AminoMsg {
-  readonly type: "cosmos-sdk/MsgGrantAllowance";
+  readonly type: typeof MsgGrantAllowanceAminoType;
   readonly value: {
     granter: string;
     grantee: string;
@@ -39,7 +46,7 @@ export interface AminoMsgGrantAllowance extends AminoMsg {
 }
 
 export interface AminoMsgRevokeAllowance extends AminoMsg {
-  readonly type: "cosmos-sdk/MsgRevokeAllowance";
+  readonly type: typeof MsgRevokeAllowanceAminoType;
   readonly value: {
     granter: string;
     grantee: string;

--- a/packages/core/src/aminomessages/cosmos/registry.ts
+++ b/packages/core/src/aminomessages/cosmos/registry.ts
@@ -12,25 +12,37 @@ import {
   MsgGrantAllowance,
   MsgRevokeAllowance,
 } from "cosmjs-types/cosmos/feegrant/v1beta1/tx";
+import {
+  AllowedMsgAllowanceTypeUrl,
+  BasicAllowanceTypeUrl,
+  GenericAuthorizationTypeUrl,
+  MsgGrantAllowanceTypeUrl,
+  MsgGrantTypeUrl,
+  MsgRevokeAllowanceTypeUrl,
+  MsgRevokeTypeUrl,
+  PeriodicAllowanceTypeUrl,
+  StakeAuthorizationTypeUrl,
+} from "../../const";
+import SendAuthorizationTypeUrl from "../../const/cosmos/bank";
 
 export const cosmosRegistryTypes: ReadonlyArray<[string, GeneratedType]> = [
   // x/authz
-  ["/cosmos.authz.v1beta1.GenericAuthorization", GenericAuthorization],
-  ["/cosmos.authz.v1beta1.MsgGrant", MsgGrant],
-  ["/cosmos.authz.v1beta1.MsgRevoke", MsgRevoke],
+  [GenericAuthorizationTypeUrl, GenericAuthorization],
+  [MsgGrantTypeUrl, MsgGrant],
+  [MsgRevokeTypeUrl, MsgRevoke],
 
   // x/bank
-  ["/cosmos.bank.v1beta1.SendAuthorization", SendAuthorization],
+  [SendAuthorizationTypeUrl, SendAuthorization],
 
   // x/feegrant
-  ["/cosmos.feegrant.v1beta1.BasicAllowance", BasicAllowance],
-  ["/cosmos.feegrant.v1beta1.PeriodicAllowance", PeriodicAllowance],
-  ["/cosmos.feegrant.v1beta1.AllowedMsgAllowance", AllowedMsgAllowance],
-  ["/cosmos.feegrant.v1beta1.MsgGrantAllowance", MsgGrantAllowance],
-  ["/cosmos.feegrant.v1beta1.MsgRevokeAllowance", MsgRevokeAllowance],
+  [BasicAllowanceTypeUrl, BasicAllowance],
+  [PeriodicAllowanceTypeUrl, PeriodicAllowance],
+  [AllowedMsgAllowanceTypeUrl, AllowedMsgAllowance],
+  [MsgGrantAllowanceTypeUrl, MsgGrantAllowance],
+  [MsgRevokeAllowanceTypeUrl, MsgRevokeAllowance],
 
   // x/staking
-  ["/cosmos.staking.v1beta1.StakeAuthorization", StakeAuthorization],
+  [StakeAuthorizationTypeUrl, StakeAuthorization],
 ];
 
 export default cosmosRegistryTypes;

--- a/packages/core/src/aminomessages/cosmos/staking/authorizations.ts
+++ b/packages/core/src/aminomessages/cosmos/staking/authorizations.ts
@@ -2,7 +2,10 @@ import { AminoConverters } from "@cosmjs/stargate";
 import { Any } from "cosmjs-types/google/protobuf/any";
 import { StakeAuthorization } from "cosmjs-types/cosmos/staking/v1beta1/authz";
 import { AminoStakeAuthorization } from "./messages";
-import { StakeAuthorizationTypeUrl } from "../../../const";
+import {
+  StakeAuthorizationAminoType,
+  StakeAuthorizationTypeUrl,
+} from "../../../const";
 
 export function stakeAuthorizationToAny(
   authorization: StakeAuthorization
@@ -15,8 +18,8 @@ export function stakeAuthorizationToAny(
 
 export function createStakeAuthorizationConverters(): AminoConverters {
   return {
-    "/cosmos.bank.v1beta1.StakeAuthorization": {
-      aminoType: "cosmos-sdk/StakeAuthorization",
+    [StakeAuthorizationTypeUrl]: {
+      aminoType: StakeAuthorizationAminoType,
       toAmino: (
         authorization: Any["value"]
       ): AminoStakeAuthorization["value"] => {

--- a/packages/core/src/aminomessages/cosmos/staking/messages.ts
+++ b/packages/core/src/aminomessages/cosmos/staking/messages.ts
@@ -1,11 +1,12 @@
-import { Coin, AminoMsg } from "@cosmjs/amino";
+import { AminoMsg, Coin } from "@cosmjs/amino";
 import {
   AuthorizationType,
   StakeAuthorization_Validators,
 } from "cosmjs-types/cosmos/staking/v1beta1/authz";
+import { StakeAuthorizationAminoType } from "../../../const";
 
 export interface AminoStakeAuthorization extends AminoMsg {
-  readonly type: "cosmos-sdk/StakeAuthorization";
+  readonly type: typeof StakeAuthorizationAminoType;
   readonly value: {
     max_tokens?: Coin;
     allow_list?: StakeAuthorization_Validators | undefined;

--- a/packages/core/src/aminomessages/desmjs/converter.ts
+++ b/packages/core/src/aminomessages/desmjs/converter.ts
@@ -1,11 +1,14 @@
 import { AminoConverters } from "@cosmjs/stargate";
 import { MsgAuthenticate } from "@desmoslabs/desmjs-types/desmjs/msgs";
 import { AminoMsgAuthenticate } from "./messages";
+import MsgAuthenticateTypeUrl, {
+  MsgAuthenticateAminoType,
+} from "../../const/desmjs";
 
 export function createDesmJSConverters(): AminoConverters {
   return {
-    "/desmjs.v1.MsgAuthenticate": {
-      aminoType: "desmjs/MsgAuthenticate",
+    [MsgAuthenticateTypeUrl]: {
+      aminoType: MsgAuthenticateAminoType,
       toAmino: (value: MsgAuthenticate): AminoMsgAuthenticate["value"] => ({
         user: value.user,
         nonce: value.nonce,

--- a/packages/core/src/aminomessages/desmjs/messages.ts
+++ b/packages/core/src/aminomessages/desmjs/messages.ts
@@ -1,7 +1,8 @@
 import { AminoMsg } from "@cosmjs/amino";
+import { MsgAuthenticateAminoType } from "../../const";
 
 export interface AminoMsgAuthenticate extends AminoMsg {
-  readonly type: "desmjs/MsgAuthenticate";
+  readonly type: MsgAuthenticateAminoType;
   readonly value: {
     user: string;
     nonce: Uint8Array;

--- a/packages/core/src/aminomessages/posts/converter.ts
+++ b/packages/core/src/aminomessages/posts/converter.ts
@@ -25,7 +25,24 @@ import {
 } from "./messages";
 import { isAminoConverter } from "../../types";
 import { AminoAttachment, AminoEntities, AminoMedia, AminoPoll } from "./types";
-import { MediaTypeUrl, PollTypeUrl } from "../../const";
+import {
+  MediaAminoType,
+  MediaTypeUrl,
+  MsgAddPostAttachmentAminoType,
+  MsgAddPostAttachmentTypeUrl,
+  MsgAnswerPollAminoType,
+  MsgAnswerPollTypeUrl,
+  MsgCreatePostAminoType,
+  MsgCreatePostTypeUrl,
+  MsgDeletePostAminoType,
+  MsgDeletePostTypeUrl,
+  MsgEditPostAminoType,
+  MsgEditPostTypeUrl,
+  MsgRemovePostAttachmentAminoType,
+  MsgRemovePostAttachmentTypeUrl,
+  PollAminoType,
+  PollTypeUrl,
+} from "../../const";
 
 /**
  * Converts the given `Poll` into an `Any` instance so that it can be used within `MsgCreatePost` and `MsgAddPostAttachment`.
@@ -50,8 +67,8 @@ export function mediaToAny(media: Media): Any {
 }
 
 export const attachmentConverters: AminoConverters = {
-  "/desmos.posts.v2.Poll": {
-    aminoType: "desmos/Poll",
+  [PollTypeUrl]: {
+    aminoType: PollAminoType,
     toAmino: (msg: Any): AminoPoll["value"] => {
       const poll = Poll.decode(msg.value);
       return {
@@ -75,8 +92,8 @@ export const attachmentConverters: AminoConverters = {
         })
       ),
   },
-  "/desmos.posts.v2.Media": {
-    aminoType: "desmos/Media",
+  [MediaTypeUrl]: {
+    aminoType: MediaAminoType,
     toAmino: (msg: Any): AminoMedia["value"] => {
       const media = Media.decode(msg.value);
       return {
@@ -141,8 +158,8 @@ function convertEntitiesFromAmino(entities: AminoEntities): Entities {
  */
 export function createPostsConverters(): AminoConverters {
   return {
-    "/desmos.posts.v2.MsgCreatePost": {
-      aminoType: "desmos/MsgCreatePost",
+    [MsgCreatePostTypeUrl]: {
+      aminoType: MsgCreatePostAminoType,
       toAmino: (msg: MsgCreatePost): AminoMsgCreatePost["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         section_id: msg.sectionId,
@@ -182,8 +199,8 @@ export function createPostsConverters(): AminoConverters {
         })),
       }),
     },
-    "/desmos.posts.v2.MsgEditPost": {
-      aminoType: "desmos/MsgEditPost",
+    [MsgEditPostTypeUrl]: {
+      aminoType: MsgEditPostAminoType,
       toAmino: (msg: MsgEditPost): AminoMsgEditPost["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         post_id: msg.postId.toString(),
@@ -205,8 +222,8 @@ export function createPostsConverters(): AminoConverters {
         editor: msg.editor,
       }),
     },
-    "/desmos.posts.v2.MsgDeletePost": {
-      aminoType: "desmos/MsgDeletePost",
+    [MsgDeletePostTypeUrl]: {
+      aminoType: MsgDeletePostAminoType,
       toAmino: (msg: MsgDeletePost): AminoMsgDeletePost["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         post_id: msg.postId.toString(),
@@ -218,8 +235,8 @@ export function createPostsConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.posts.v2.MsgAddPostAttachment": {
-      aminoType: "desmos/MsgAddPostAttachment",
+    [MsgAddPostAttachmentTypeUrl]: {
+      aminoType: MsgAddPostAttachmentAminoType,
       toAmino: (
         msg: MsgAddPostAttachment
       ): AminoMsgAddPostAttachment["value"] => {
@@ -240,8 +257,8 @@ export function createPostsConverters(): AminoConverters {
         editor: msg.editor,
       }),
     },
-    "/desmos.posts.v2.MsgRemovePostAttachment": {
-      aminoType: "desmos/MsgRemovePostAttachment",
+    [MsgRemovePostAttachmentTypeUrl]: {
+      aminoType: MsgRemovePostAttachmentAminoType,
       toAmino: (
         msg: MsgRemovePostAttachment
       ): AminoMsgRemovePostAttachment["value"] => ({
@@ -259,8 +276,8 @@ export function createPostsConverters(): AminoConverters {
         editor: msg.editor,
       }),
     },
-    "/desmos.posts.v2.MsgAnswerPoll": {
-      aminoType: "desmos/MsgAnswerPoll",
+    [MsgAnswerPollTypeUrl]: {
+      aminoType: MsgAnswerPollAminoType,
       toAmino: (msg: MsgAnswerPoll): AminoMsgAnswerPoll["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         post_id: msg.postId.toString(),

--- a/packages/core/src/aminomessages/posts/messages.ts
+++ b/packages/core/src/aminomessages/posts/messages.ts
@@ -1,9 +1,17 @@
 import { AminoMsg } from "@cosmjs/amino";
 import { ReplySetting } from "@desmoslabs/desmjs-types/desmos/posts/v2/models";
 import { AminoAttachment, AminoEntities, AminoPostReference } from "./types";
+import {
+  MsgAddPostAttachmentAminoType,
+  MsgAnswerPollAminoType,
+  MsgCreatePostAminoType,
+  MsgDeletePostAminoType,
+  MsgEditPostAminoType,
+  MsgRemovePostAttachmentAminoType,
+} from "../../const";
 
 export interface AminoMsgCreatePost extends AminoMsg {
-  readonly type: "desmos/MsgCreatePost";
+  readonly type: typeof MsgCreatePostAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;
@@ -20,7 +28,7 @@ export interface AminoMsgCreatePost extends AminoMsg {
 }
 
 export interface AminoMsgEditPost extends AminoMsg {
-  readonly type: "desmos/MsgEditPost";
+  readonly type: typeof MsgEditPostAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -32,7 +40,7 @@ export interface AminoMsgEditPost extends AminoMsg {
 }
 
 export interface AminoMsgDeletePost extends AminoMsg {
-  readonly type: "desmos/MsgDeletePost";
+  readonly type: typeof MsgDeletePostAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -41,7 +49,7 @@ export interface AminoMsgDeletePost extends AminoMsg {
 }
 
 export interface AminoMsgAddPostAttachment extends AminoMsg {
-  readonly type: "desmos/MsgAddPostAttachment";
+  readonly type: typeof MsgAddPostAttachmentAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -51,7 +59,7 @@ export interface AminoMsgAddPostAttachment extends AminoMsg {
 }
 
 export interface AminoMsgRemovePostAttachment extends AminoMsg {
-  readonly type: "desmos/MsgRemovePostAttachment";
+  readonly type: typeof MsgRemovePostAttachmentAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -61,7 +69,7 @@ export interface AminoMsgRemovePostAttachment extends AminoMsg {
 }
 
 export interface AminoMsgAnswerPoll extends AminoMsg {
-  readonly type: "desmos/MsgAnswerPoll";
+  readonly type: typeof MsgAnswerPollAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;

--- a/packages/core/src/aminomessages/posts/types.ts
+++ b/packages/core/src/aminomessages/posts/types.ts
@@ -5,6 +5,7 @@ import {
   PostReferenceType,
   TextTag,
 } from "@desmoslabs/desmjs-types/desmos/posts/v2/models";
+import { MediaAminoType, PollAminoType } from "../../const";
 
 export interface AminoEntities {
   readonly hashtags: TextTag[];
@@ -22,7 +23,7 @@ export interface AminoUrl {
 export interface AminoAttachment extends AminoMsg {}
 
 export interface AminoPoll extends AminoAttachment {
-  readonly type: "desmos/Poll";
+  readonly type: typeof PollAminoType;
   readonly value: {
     question: string;
     provided_answers: Poll_ProvidedAnswer[];
@@ -34,7 +35,7 @@ export interface AminoPoll extends AminoAttachment {
 }
 
 export interface AminoMedia extends AminoAttachment {
-  readonly type: "desmos/Media";
+  readonly type: typeof MediaAminoType;
   readonly value: {
     uri: string;
     mime_type: string;

--- a/packages/core/src/aminomessages/profiles/converter.ts
+++ b/packages/core/src/aminomessages/profiles/converter.ts
@@ -49,16 +49,41 @@ import {
   AminoAddressData,
   AminoBase58Address,
   AminoBech32Address,
-  AminoHexAddress,
   AminoCosmosMultiSignature,
+  AminoHexAddress,
   AminoSignature,
   AminoSingleSignature,
 } from "./types";
 import {
+  Base58AddressAminoType,
   Base58AddressTypeUrl,
+  Bech32AddressAminoType,
   Bech32AddressTypeUrl,
+  CosmosMultiSignatureAminoType,
   CosmosMultiSignatureTypeUrl,
+  HexAddressAminoType,
   HexAddressTypeUrl,
+  MsgAcceptDTagTransferRequestAminoType,
+  MsgAcceptDTagTransferRequestTypeUrl,
+  MsgCancelDTagTransferRequestAminoType,
+  MsgCancelDTagTransferRequestTypeUrl,
+  MsgDeleteProfileAminoType,
+  MsgDeleteProfileTypeUrl,
+  MsgLinkApplicationAminoType,
+  MsgLinkApplicationTypeUrl,
+  MsgLinkChainAccountAminoType,
+  MsgLinkChainAccountTypeUrl,
+  MsgRefuseDTagTransferRequestAminoType,
+  MsgRefuseDTagTransferRequestTypeUrl,
+  MsgRequestDTagTransferAminoType,
+  MsgRequestDTagTransferTypeUrl,
+  MsgSaveProfileAminoType,
+  MsgSaveProfileTypeUrl,
+  MsgUnlinkApplicationAminoType,
+  MsgUnlinkApplicationTypeUrl,
+  MsgUnlinkChainAccountAminoType,
+  MsgUnlinkChainAccountTypeUrl,
+  SingleSignatureAminoType,
   SingleSignatureTypeUrl,
 } from "../../const";
 
@@ -94,7 +119,7 @@ function convertAddressData(address: Any): AminoAddressData {
   if (address.typeUrl === Bech32AddressTypeUrl) {
     const bech32Address = Bech32Address.decode(address.value);
     return {
-      type: "desmos/Bech32Address",
+      type: Bech32AddressAminoType,
       value: {
         prefix: bech32Address.prefix,
         value: bech32Address.value,
@@ -105,7 +130,7 @@ function convertAddressData(address: Any): AminoAddressData {
   if (address.typeUrl === Base58AddressTypeUrl) {
     const base58Address = Base58Address.decode(address.value);
     return {
-      type: "desmos/Base58Address",
+      type: Base58AddressAminoType,
       value: {
         value: base58Address.value,
       },
@@ -115,7 +140,7 @@ function convertAddressData(address: Any): AminoAddressData {
   if (address.typeUrl === HexAddressTypeUrl) {
     const hexAddress = HexAddress.decode(address.value);
     return {
-      type: "desmos/HexAddress",
+      type: HexAddressAminoType,
       value: {
         prefix: hexAddress.prefix,
         values: hexAddress.value,
@@ -148,17 +173,17 @@ export function hexAddressToAny(address: HexAddress): Any {
 }
 
 function convertAminoAddressData(address: AminoAddressData): Any {
-  if (address.type === "desmos/Bech32Address") {
+  if (address.type === Bech32AddressAminoType) {
     const addressData = address.value as AminoBech32Address["value"];
     return bech32AddressToAny(addressData);
   }
 
-  if (address.type === "desmos/Base58Address") {
+  if (address.type === Base58AddressAminoType) {
     const addressData = address.value as AminoBase58Address["value"];
     return base58AddressToAny(addressData);
   }
 
-  if (address.type === "desmos/HexAddress") {
+  if (address.type === HexAddressAminoType) {
     const addressData = address.value as AminoHexAddress["value"];
     return hexAddressToAny(addressData);
   }
@@ -198,7 +223,7 @@ function convertSignatureData(signatureData: Any): AminoSignature {
   if (signatureData.typeUrl === SingleSignatureTypeUrl) {
     const data = SingleSignature.decode(signatureData.value);
     return {
-      type: "desmos/SingleSignature",
+      type: SingleSignatureAminoType,
       value: {
         mode: SignatureValueType[data.valueType],
         signature: toBase64(data.signature),
@@ -210,7 +235,7 @@ function convertSignatureData(signatureData: Any): AminoSignature {
     const data = CosmosMultiSignature.decode(signatureData.value);
     const signatures = data.signatures.map(convertSignatureData);
     return {
-      type: "desmos/CosmosMultiSignature",
+      type: CosmosMultiSignatureAminoType,
       value: {
         bit_array: convertCompactBitArray(data.bitArray),
         signatures,
@@ -238,7 +263,7 @@ export function cosmosMultiSignatureToAny(
 }
 
 function convertAminoSignature(signature: AminoSignature): Any {
-  if (signature.type === "desmos/SingleSignature") {
+  if (signature.type === SingleSignatureAminoType) {
     const signatureData = signature.value as AminoSingleSignature["value"];
     return singleSignatureToAny(
       SingleSignature.fromPartial({
@@ -248,7 +273,7 @@ function convertAminoSignature(signature: AminoSignature): Any {
     );
   }
 
-  if (signature.type === "desmos/CosmosMultiSignature") {
+  if (signature.type === CosmosMultiSignatureAminoType) {
     const signatureData = signature.value as AminoCosmosMultiSignature["value"];
     return cosmosMultiSignatureToAny(
       CosmosMultiSignature.fromPartial({
@@ -267,8 +292,8 @@ function convertAminoSignature(signature: AminoSignature): Any {
 export function createProfilesConverters(): AminoConverters {
   return {
     // Profiles module
-    "/desmos.profiles.v3.MsgSaveProfile": {
-      aminoType: "desmos/MsgSaveProfile",
+    [MsgSaveProfileTypeUrl]: {
+      aminoType: MsgSaveProfileAminoType,
       toAmino: (value: MsgSaveProfile): AminoMsgSaveProfile["value"] => ({
         bio: value.bio,
         creator: value.creator,
@@ -286,8 +311,8 @@ export function createProfilesConverters(): AminoConverters {
         coverPicture: msg.cover_picture ?? "",
       }),
     },
-    "/desmos.profiles.v3.MsgDeleteProfile": {
-      aminoType: "desmos/MsgDeleteProfile",
+    [MsgDeleteProfileTypeUrl]: {
+      aminoType: MsgDeleteProfileAminoType,
       toAmino: (value: MsgDeleteProfile): AminoMsgDeleteProfile["value"] => ({
         creator: value.creator,
       }),
@@ -295,8 +320,8 @@ export function createProfilesConverters(): AminoConverters {
         creator: msg.creator,
       }),
     },
-    "/desmos.profiles.v3.MsgRequestDTagTransfer": {
-      aminoType: "desmos/MsgRequestDTagTransfer",
+    [MsgRequestDTagTransferTypeUrl]: {
+      aminoType: MsgRequestDTagTransferAminoType,
       toAmino: ({
         receiver,
         sender,
@@ -312,8 +337,8 @@ export function createProfilesConverters(): AminoConverters {
         sender,
       }),
     },
-    "/desmos.profiles.v3.MsgAcceptDTagTransferRequest": {
-      aminoType: "desmos/MsgAcceptDTagTransferRequest",
+    [MsgAcceptDTagTransferRequestTypeUrl]: {
+      aminoType: MsgAcceptDTagTransferRequestAminoType,
       toAmino: ({
         newDtag,
         sender,
@@ -333,8 +358,8 @@ export function createProfilesConverters(): AminoConverters {
         receiver,
       }),
     },
-    "/desmos.profiles.v3.MsgRefuseDTagTransferRequest": {
-      aminoType: "desmos/MsgRefuseDTagTransferRequest",
+    [MsgRefuseDTagTransferRequestTypeUrl]: {
+      aminoType: MsgRefuseDTagTransferRequestAminoType,
       toAmino: ({
         sender,
         receiver,
@@ -350,8 +375,8 @@ export function createProfilesConverters(): AminoConverters {
         receiver,
       }),
     },
-    "/desmos.profiles.v3.MsgCancelDTagTransferRequest": {
-      aminoType: "desmos/MsgCancelDTagTransferRequest",
+    [MsgCancelDTagTransferRequestTypeUrl]: {
+      aminoType: MsgCancelDTagTransferRequestAminoType,
       toAmino: ({
         sender,
         receiver,
@@ -367,8 +392,8 @@ export function createProfilesConverters(): AminoConverters {
         receiver,
       }),
     },
-    "/desmos.profiles.v3.MsgLinkApplication": {
-      aminoType: "desmos/MsgLinkApplication",
+    [MsgLinkApplicationTypeUrl]: {
+      aminoType: MsgLinkApplicationAminoType,
       toAmino: (msg: MsgLinkApplication): AminoMsgLinkApplication["value"] => ({
         sender: msg.sender,
         link_data: {
@@ -416,8 +441,8 @@ export function createProfilesConverters(): AminoConverters {
         timeoutTimestamp: Long.fromString(msg.timeout_timestamp || "0", true),
       }),
     },
-    "/desmos.profiles.v3.MsgUnlinkApplication": {
-      aminoType: "desmos/MsgUnlinkApplication",
+    [MsgUnlinkApplicationTypeUrl]: {
+      aminoType: MsgUnlinkApplicationAminoType,
       toAmino: (
         msg: MsgUnlinkApplication
       ): AminoMsgUnlinkApplication["value"] => ({
@@ -433,8 +458,8 @@ export function createProfilesConverters(): AminoConverters {
         username: msg.username,
       }),
     },
-    "/desmos.profiles.v3.MsgLinkChainAccount": {
-      aminoType: "desmos/MsgLinkChainAccount",
+    [MsgLinkChainAccountTypeUrl]: {
+      aminoType: MsgLinkChainAccountAminoType,
       toAmino: (
         msg: MsgLinkChainAccount
       ): AminoMsgLinkChainAccount["value"] => {
@@ -464,7 +489,7 @@ export function createProfilesConverters(): AminoConverters {
       fromAmino: (
         msg: AminoMsgLinkChainAccount["value"]
       ): MsgLinkChainAccount => {
-        if (msg.chain_address.type !== "desmos/Bech32Address") {
+        if (msg.chain_address.type !== Bech32AddressAminoType) {
           throw new Error(
             `Invalid chain_address type "${msg.chain_address.type}"`
           );
@@ -489,8 +514,8 @@ export function createProfilesConverters(): AminoConverters {
         };
       },
     },
-    "/desmos.profiles.v3.MsgUnlinkChainAccount": {
-      aminoType: "desmos/MsgUnlinkChainAccount",
+    [MsgUnlinkChainAccountTypeUrl]: {
+      aminoType: MsgUnlinkChainAccountAminoType,
       toAmino: (
         msg: MsgUnlinkChainAccount
       ): AminoMsgUnlinkChainAccount["value"] => ({

--- a/packages/core/src/aminomessages/profiles/messages.ts
+++ b/packages/core/src/aminomessages/profiles/messages.ts
@@ -1,8 +1,20 @@
 import { AminoMsg } from "@cosmjs/amino";
 import { AminoAddressData } from "./types";
+import {
+  MsgAcceptDTagTransferRequestAminoType,
+  MsgCancelDTagTransferRequestAminoType,
+  MsgDeleteProfileAminoType,
+  MsgLinkApplicationAminoType,
+  MsgLinkChainAccountAminoType,
+  MsgRefuseDTagTransferRequestAminoType,
+  MsgRequestDTagTransferAminoType,
+  MsgSaveProfileAminoType,
+  MsgUnlinkApplicationAminoType,
+  MsgUnlinkChainAccountAminoType,
+} from "../../const";
 
 export interface AminoMsgSaveProfile extends AminoMsg {
-  readonly type: "desmos/MsgSaveProfile";
+  readonly type: typeof MsgSaveProfileAminoType;
   readonly value: {
     creator: string;
     dtag: string;
@@ -14,14 +26,14 @@ export interface AminoMsgSaveProfile extends AminoMsg {
 }
 
 export interface AminoMsgDeleteProfile extends AminoMsg {
-  readonly type: "desmos/MsgDeleteProfile";
+  readonly type: typeof MsgDeleteProfileAminoType;
   readonly value: {
     creator: string;
   };
 }
 
 export interface AminoMsgRequestDTagTransfer extends AminoMsg {
-  readonly type: "desmos/MsgRequestDTagTransfer";
+  readonly type: typeof MsgRequestDTagTransferAminoType;
   readonly value: {
     receiver: string;
     sender: string;
@@ -29,7 +41,7 @@ export interface AminoMsgRequestDTagTransfer extends AminoMsg {
 }
 
 export interface AminoMsgAcceptDTagTransferRequest extends AminoMsg {
-  readonly type: "desmos/AminoMsgAcceptDTagTransferRequest";
+  readonly type: typeof MsgAcceptDTagTransferRequestAminoType;
   readonly value: {
     new_dtag: string;
     sender: string;
@@ -38,7 +50,7 @@ export interface AminoMsgAcceptDTagTransferRequest extends AminoMsg {
 }
 
 export interface AminoMsgRefuseDTagTransferRequest extends AminoMsg {
-  readonly type: "desmos/AminoMsgRefuseDTagTransferRequest";
+  readonly type: typeof MsgRefuseDTagTransferRequestAminoType;
   readonly value: {
     sender: string;
     receiver: string;
@@ -46,7 +58,7 @@ export interface AminoMsgRefuseDTagTransferRequest extends AminoMsg {
 }
 
 export interface AminoMsgCancelDTagTransferRequest extends AminoMsg {
-  readonly type: "desmos/AminoMsgCancelDTagTransferRequest";
+  readonly type: typeof MsgCancelDTagTransferRequestAminoType;
   readonly value: {
     sender: string;
     receiver: string;
@@ -54,7 +66,7 @@ export interface AminoMsgCancelDTagTransferRequest extends AminoMsg {
 }
 
 export interface AminoMsgLinkApplication extends AminoMsg {
-  readonly type: "desmos/MsgLinkApplication";
+  readonly type: typeof MsgLinkApplicationAminoType;
   readonly value: {
     sender: string;
     link_data: {
@@ -73,7 +85,7 @@ export interface AminoMsgLinkApplication extends AminoMsg {
 }
 
 export interface AminoMsgUnlinkApplication extends AminoMsg {
-  readonly type: "desmos/MsgUnlinkApplication";
+  readonly type: typeof MsgUnlinkApplicationAminoType;
   readonly value: {
     signer: string;
     application: string;
@@ -82,7 +94,7 @@ export interface AminoMsgUnlinkApplication extends AminoMsg {
 }
 
 export interface AminoMsgLinkChainAccount extends AminoMsg {
-  readonly type: "desmos/MsgLinkChainAccount";
+  readonly type: typeof MsgLinkChainAccountAminoType;
   readonly value: {
     signer: string;
     chain_address: AminoAddressData;
@@ -101,7 +113,7 @@ export interface AminoMsgLinkChainAccount extends AminoMsg {
 }
 
 export interface AminoMsgUnlinkChainAccount extends AminoMsg {
-  readonly type: "desmos/MsgUnlinkChainAccount";
+  readonly type: typeof MsgUnlinkChainAccountAminoType;
   readonly value: {
     chain_name: string;
     owner: string;

--- a/packages/core/src/aminomessages/profiles/types.ts
+++ b/packages/core/src/aminomessages/profiles/types.ts
@@ -1,9 +1,16 @@
 import { AminoMsg } from "@cosmjs/amino";
+import {
+  Base58AddressAminoType,
+  Bech32AddressAminoType,
+  CosmosMultiSignatureAminoType,
+  HexAddressAminoType,
+  SingleSignatureAminoType,
+} from "../../const";
 
 export interface AminoAddressData extends AminoMsg {}
 
 export interface AminoBech32Address extends AminoMsg {
-  readonly type: "desmos/Bech32Address";
+  readonly type: typeof Bech32AddressAminoType;
   readonly value: {
     readonly value: string;
     readonly prefix: string;
@@ -11,14 +18,14 @@ export interface AminoBech32Address extends AminoMsg {
 }
 
 export interface AminoBase58Address extends AminoMsg {
-  readonly type: "desmos/Base58Address";
+  readonly type: typeof Base58AddressAminoType;
   readonly value: {
     readonly value: string;
   };
 }
 
 export interface AminoHexAddress extends AminoMsg {
-  readonly type: "desmos/HexAddress";
+  readonly type: typeof HexAddressAminoType;
   readonly value: {
     readonly value: string;
     readonly prefix: string;
@@ -28,7 +35,7 @@ export interface AminoHexAddress extends AminoMsg {
 export interface AminoSignature extends AminoMsg {}
 
 export interface AminoSingleSignature extends AminoSignature {
-  readonly type: "desmos/SingleSignature";
+  readonly type: typeof SingleSignatureAminoType;
   readonly value: {
     readonly value_type: number;
     readonly signature: string;
@@ -36,7 +43,7 @@ export interface AminoSingleSignature extends AminoSignature {
 }
 
 export interface AminoCosmosMultiSignature extends AminoSignature {
-  readonly type: "desmos/CosmosMultiSignature";
+  readonly type: typeof CosmosMultiSignatureAminoType;
   value: {
     readonly bit_array: string;
     readonly signatures: [AminoSignature];

--- a/packages/core/src/aminomessages/reactions/converter.ts
+++ b/packages/core/src/aminomessages/reactions/converter.ts
@@ -31,7 +31,21 @@ import {
 } from "./messages";
 import { isAminoConverter } from "../../types";
 import {
+  FreeTextValueAminoType,
   FreeTextValueTypeUrl,
+  MsgAddReactionAminoType,
+  MsgAddReactionTypeUrl,
+  MsgAddRegisteredReactionAminoType,
+  MsgAddRegisteredReactionTypeUrl,
+  MsgEditRegisteredReactionAminoType,
+  MsgEditRegisteredReactionTypeUrl,
+  MsgRemoveReactionAminoType,
+  MsgRemoveReactionTypeUrl,
+  MsgRemoveRegisteredReactionAminoType,
+  MsgRemoveRegisteredReactionTypeUrl,
+  MsgSetReactionsParamsAminoType,
+  MsgSetReactionsParamsTypeUrl,
+  RegisteredReactionValueAminoType,
   RegisteredReactionValueTypeUrl,
 } from "../../const";
 
@@ -52,8 +66,8 @@ export function convertFreeTextValueToAny(value: FreeTextValue): Any {
 }
 
 export const reactionValueConverters: AminoConverters = {
-  "/desmos.reactions.v1.RegisteredReactionValue": {
-    aminoType: "desmos/RegisteredReactionValue",
+  [RegisteredReactionValueTypeUrl]: {
+    aminoType: RegisteredReactionValueAminoType,
     toAmino: (msg: Any): AminoRegisteredReaction["value"] => {
       const reaction = RegisteredReactionValue.decode(msg.value);
       return {
@@ -67,8 +81,8 @@ export const reactionValueConverters: AminoConverters = {
         })
       ),
   },
-  "/desmos.reactions.v1.FreeTextValue": {
-    aminoType: "desmos/FreeTextValue",
+  [FreeTextValueTypeUrl]: {
+    aminoType: FreeTextValueAminoType,
     toAmino: (msg: Any): AminoFreeTextReaction["value"] => {
       const reaction = FreeTextValue.decode(msg.value);
       return {
@@ -125,8 +139,8 @@ export function convertFreeTextValueParamsFromAmino(
  */
 export function createReactionsConverters(): AminoConverters {
   return {
-    "/desmos.reactions.v1.MsgAddReaction": {
-      aminoType: "desmos/MsgAddReaction",
+    [MsgAddReactionTypeUrl]: {
+      aminoType: MsgAddReactionAminoType,
       toAmino: (msg: MsgAddReaction): AminoMsgAddReaction["value"] => {
         assertDefinedAndNotNull(msg.value, "reaction value not defined");
         return {
@@ -143,8 +157,8 @@ export function createReactionsConverters(): AminoConverters {
         user: msg.user,
       }),
     },
-    "/desmos.reactions.v1.MsgRemoveReaction": {
-      aminoType: "desmos/MsgRemoveReaction",
+    [MsgRemoveReactionTypeUrl]: {
+      aminoType: MsgRemoveReactionAminoType,
       toAmino: (msg: MsgRemoveReaction): AminoMsgRemoveReaction["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         post_id: msg.postId.toString(),
@@ -158,8 +172,8 @@ export function createReactionsConverters(): AminoConverters {
         user: msg.user,
       }),
     },
-    "/desmos.reactions.v1.MsgAddRegisteredReaction": {
-      aminoType: "desmos/MsgAddRegisteredReaction",
+    [MsgAddRegisteredReactionTypeUrl]: {
+      aminoType: MsgAddRegisteredReactionAminoType,
       toAmino: (
         msg: MsgAddRegisteredReaction
       ): AminoMsgAddRegisteredReaction["value"] => ({
@@ -177,8 +191,8 @@ export function createReactionsConverters(): AminoConverters {
         user: msg.user,
       }),
     },
-    "/desmos.reactions.v1.MsgEditRegisteredReaction": {
-      aminoType: "desmos/MsgEditRegisteredReaction",
+    [MsgEditRegisteredReactionTypeUrl]: {
+      aminoType: MsgEditRegisteredReactionAminoType,
       toAmino: (
         msg: MsgEditRegisteredReaction
       ): AminoMsgEditRegisteredReaction["value"] => ({
@@ -198,8 +212,8 @@ export function createReactionsConverters(): AminoConverters {
         user: msg.user,
       }),
     },
-    "/desmos.reactions.v1.MsgRemoveRegisteredReaction": {
-      aminoType: "desmos/MsgRemoveRegisteredReaction",
+    [MsgRemoveRegisteredReactionTypeUrl]: {
+      aminoType: MsgRemoveRegisteredReactionAminoType,
       toAmino: (
         msg: MsgRemoveRegisteredReaction
       ): AminoMsgRemoveRegisteredReaction["value"] => ({
@@ -215,8 +229,8 @@ export function createReactionsConverters(): AminoConverters {
         user: msg.user,
       }),
     },
-    "/desmos.reactions.v1.MsgSetReactionsParams": {
-      aminoType: "desmos/MsgSetReactionsParams",
+    [MsgSetReactionsParamsTypeUrl]: {
+      aminoType: MsgSetReactionsParamsAminoType,
       toAmino: (
         msg: MsgSetReactionsParams
       ): AminoMsgSetReactionsParams["value"] => ({

--- a/packages/core/src/aminomessages/reactions/messages.ts
+++ b/packages/core/src/aminomessages/reactions/messages.ts
@@ -1,9 +1,17 @@
 import { AminoMsg } from "@cosmjs/amino";
 import { RegisteredReactionValueParams } from "@desmoslabs/desmjs-types/build/desmos/reactions/v1/models";
 import { AminoFreeTextValueParams, AminoReaction } from "./types";
+import {
+  MsgAddReactionAminoType,
+  MsgAddRegisteredReactionAminoType,
+  MsgEditRegisteredReactionAminoType,
+  MsgRemoveReactionAminoType,
+  MsgRemoveRegisteredReactionAminoType,
+  MsgSetReactionsParamsAminoType,
+} from "../../const";
 
 export interface AminoMsgAddReaction extends AminoMsg {
-  readonly type: "desmos/MsgAddReaction";
+  readonly type: typeof MsgAddReactionAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -13,7 +21,7 @@ export interface AminoMsgAddReaction extends AminoMsg {
 }
 
 export interface AminoMsgRemoveReaction extends AminoMsg {
-  readonly type: "desmos/MsgRemoveReaction";
+  readonly type: typeof MsgRemoveReactionAminoType;
   readonly value: {
     subspace_id: string;
     post_id: string;
@@ -23,7 +31,7 @@ export interface AminoMsgRemoveReaction extends AminoMsg {
 }
 
 export interface AminoMsgAddRegisteredReaction extends AminoMsg {
-  readonly type: "desmos/MsgAddRegisteredReaction";
+  readonly type: typeof MsgAddRegisteredReactionAminoType;
   readonly value: {
     subspace_id: string;
     shorthand_code: string;
@@ -33,7 +41,7 @@ export interface AminoMsgAddRegisteredReaction extends AminoMsg {
 }
 
 export interface AminoMsgEditRegisteredReaction extends AminoMsg {
-  readonly type: "desmos/MsgEditRegisteredReaction";
+  readonly type: typeof MsgEditRegisteredReactionAminoType;
   readonly value: {
     subspace_id: string;
     registered_reaction_id: number;
@@ -44,7 +52,7 @@ export interface AminoMsgEditRegisteredReaction extends AminoMsg {
 }
 
 export interface AminoMsgRemoveRegisteredReaction extends AminoMsg {
-  readonly type: "desmos/MsgRemoveRegisteredReaction";
+  readonly type: typeof MsgRemoveRegisteredReactionAminoType;
   readonly value: {
     subspace_id: string;
     registered_reaction_id: number;
@@ -53,7 +61,7 @@ export interface AminoMsgRemoveRegisteredReaction extends AminoMsg {
 }
 
 export interface AminoMsgSetReactionsParams extends AminoMsg {
-  readonly type: "desmos/MsgSetReactionsParams";
+  readonly type: typeof MsgSetReactionsParamsAminoType;
   readonly value: {
     subspace_id: string;
     registered_reaction?: RegisteredReactionValueParams;

--- a/packages/core/src/aminomessages/reactions/types.ts
+++ b/packages/core/src/aminomessages/reactions/types.ts
@@ -1,16 +1,20 @@
 import { AminoMsg } from "@cosmjs/amino";
+import {
+  FreeTextValueAminoType,
+  RegisteredReactionValueAminoType,
+} from "../../const";
 
 export interface AminoReaction extends AminoMsg {}
 
 export interface AminoRegisteredReaction extends AminoReaction {
-  readonly type: "desmos/RegisteredReactionValue";
+  readonly type: typeof RegisteredReactionValueAminoType;
   readonly value: {
     registered_reaction_id: number;
   };
 }
 
 export interface AminoFreeTextReaction extends AminoReaction {
-  readonly type: "desmos/FreeTextValue";
+  readonly type: typeof FreeTextValueAminoType;
   readonly value: {
     text: string;
   };

--- a/packages/core/src/aminomessages/relationships/converter.ts
+++ b/packages/core/src/aminomessages/relationships/converter.ts
@@ -12,14 +12,24 @@ import {
   AminoMsgDeleteRelationship,
   AminoMsgUnblockUser,
 } from "./messages";
+import {
+  MsgBlockUserAminoType,
+  MsgBlockUserTypeUrl,
+  MsgCreateRelationshipAminoType,
+  MsgCreateRelationshipTypeUrl,
+  MsgDeleteRelationshipAminoType,
+  MsgDeleteRelationshipTypeUrl,
+  MsgUnblockUserAminoType,
+  MsgUnblockUserTypeUrl,
+} from "../../const";
 
 /**
  * Creates all the Amino converters for the relationships messages.
  */
 export function createRelationshipsConverters(): AminoConverters {
   return {
-    "/desmos.relationships.v1.MsgCreateRelationship": {
-      aminoType: "desmos/MsgCreateRelationship",
+    [MsgCreateRelationshipTypeUrl]: {
+      aminoType: MsgCreateRelationshipAminoType,
       toAmino: (
         msg: MsgCreateRelationship
       ): AminoMsgCreateRelationship["value"] => ({
@@ -35,8 +45,8 @@ export function createRelationshipsConverters(): AminoConverters {
         subspaceId: Long.fromString(msg.subspace_id),
       }),
     },
-    "/desmos.relationships.v1.MsgDeleteRelationship": {
-      aminoType: "desmos/MsgDeleteRelationship",
+    [MsgDeleteRelationshipTypeUrl]: {
+      aminoType: MsgDeleteRelationshipAminoType,
       toAmino: (
         msg: MsgDeleteRelationship
       ): AminoMsgDeleteRelationship["value"] => ({
@@ -52,8 +62,8 @@ export function createRelationshipsConverters(): AminoConverters {
         subspaceId: Long.fromString(msg.subspace_id),
       }),
     },
-    "/desmos.relationships.v1.MsgBlockUser": {
-      aminoType: "desmos/MsgBlockUser",
+    [MsgBlockUserTypeUrl]: {
+      aminoType: MsgBlockUserAminoType,
       toAmino: (msg: MsgBlockUser): AminoMsgBlockUser["value"] => ({
         blocker: msg.blocker,
         blocked: msg.blocked,
@@ -67,8 +77,8 @@ export function createRelationshipsConverters(): AminoConverters {
         subspaceId: Long.fromString(msg.subspace_id),
       }),
     },
-    "/desmos.relationships.v1.MsgUnblockUser": {
-      aminoType: "desmos/MsgUnblockUser",
+    [MsgUnblockUserTypeUrl]: {
+      aminoType: MsgUnblockUserAminoType,
       toAmino: (msg: MsgUnblockUser): AminoMsgUnblockUser["value"] => ({
         blocker: msg.blocker,
         blocked: msg.blocked,

--- a/packages/core/src/aminomessages/relationships/messages.ts
+++ b/packages/core/src/aminomessages/relationships/messages.ts
@@ -1,7 +1,13 @@
 import { AminoMsg } from "@cosmjs/amino";
+import {
+  MsgBlockUserAminoType,
+  MsgCreateRelationshipAminoType,
+  MsgDeleteRelationshipAminoType,
+  MsgUnblockUserAminoType,
+} from "../../const";
 
 export interface AminoMsgCreateRelationship extends AminoMsg {
-  readonly type: "desmos/MsgCreateRelationship";
+  readonly type: typeof MsgCreateRelationshipAminoType;
   readonly value: {
     signer: string;
     counterparty: string;
@@ -10,7 +16,7 @@ export interface AminoMsgCreateRelationship extends AminoMsg {
 }
 
 export interface AminoMsgDeleteRelationship extends AminoMsg {
-  readonly type: "desmos/MsgDeleteRelationship";
+  readonly type: typeof MsgDeleteRelationshipAminoType;
   readonly value: {
     signer: string;
     counterparty: string;
@@ -19,7 +25,7 @@ export interface AminoMsgDeleteRelationship extends AminoMsg {
 }
 
 export interface AminoMsgBlockUser extends AminoMsg {
-  readonly type: "desmos/MsgBlockUser";
+  readonly type: typeof MsgBlockUserAminoType;
   readonly value: {
     blocker: string;
     blocked: string;
@@ -29,7 +35,7 @@ export interface AminoMsgBlockUser extends AminoMsg {
 }
 
 export interface AminoMsgUnblockUser extends AminoMsg {
-  readonly type: "desmos/MsgUnblockUser";
+  readonly type: typeof MsgUnblockUserAminoType;
   readonly value: {
     blocker: string;
     blocked: string;

--- a/packages/core/src/aminomessages/reports/converter.ts
+++ b/packages/core/src/aminomessages/reports/converter.ts
@@ -22,7 +22,22 @@ import {
   AminoMsgSupportStandardReason,
 } from "./messages";
 import { isAminoConverter } from "../../types";
-import { PostTargetTypeUrl, UserTargetTypeUrl } from "../../const";
+import {
+  MsgAddReasonAminoType,
+  MsgAddReasonTypeUrl,
+  MsgCreateReportAminoType,
+  MsgCreateReportTypeUrl,
+  MsgDeleteReportAminoType,
+  MsgDeleteReportTypeUrl,
+  MsgRemoveReasonAminoType,
+  MsgRemoveReasonTypeUrl,
+  MsgSupportStandardReasonAminoType,
+  MsgSupportStandardReasonTypeUrl,
+  PostTargetAminoType,
+  PostTargetTypeUrl,
+  UserTargetAminoType,
+  UserTargetTypeUrl,
+} from "../../const";
 
 export function convertUserTargetToAny(target: UserTarget): Any {
   return Any.fromPartial({
@@ -39,8 +54,8 @@ export function convertPostTargetToAny(target: PostTarget): Any {
 }
 
 export const reportTargetConverters: AminoConverters = {
-  "/desmos.reports.v1.UserTarget": {
-    aminoType: "desmos/UserTarget",
+  [UserTargetTypeUrl]: {
+    aminoType: UserTargetAminoType,
     toAmino: (msg: Any): AminoUserTarget["value"] => {
       const target = UserTarget.decode(msg.value);
       return {
@@ -54,8 +69,8 @@ export const reportTargetConverters: AminoConverters = {
         })
       ),
   },
-  "/desmos.reports.v1.PostTarget": {
-    aminoType: "desmos/PostTarget",
+  [PostTargetTypeUrl]: {
+    aminoType: PostTargetAminoType,
     toAmino: (msg: Any): AminoPostTarget["value"] => {
       const target = PostTarget.decode(msg.value);
       return {
@@ -92,8 +107,8 @@ export function convertReportTargetFromAmino(target: AminoReportTarget): Any {
  */
 export function createReportsConverters(): AminoConverters {
   return {
-    "/desmos.reports.v1.MsgCreateReport": {
-      aminoType: "desmos/MsgCreateReport",
+    [MsgCreateReportTypeUrl]: {
+      aminoType: MsgCreateReportAminoType,
       toAmino: (msg: MsgCreateReport): AminoMsgCreateReport["value"] => {
         assertDefinedAndNotNull(msg.target, "report target not defined");
         return {
@@ -112,8 +127,8 @@ export function createReportsConverters(): AminoConverters {
         target: convertReportTargetFromAmino(msg.target),
       }),
     },
-    "/desmos.reports.v1.MsgDeleteReport": {
-      aminoType: "desmos/MsgDeleteReport",
+    [MsgDeleteReportTypeUrl]: {
+      aminoType: MsgDeleteReportAminoType,
       toAmino: (msg: MsgDeleteReport): AminoMsgDeleteReport["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         report_id: msg.reportId.toString(),
@@ -125,8 +140,8 @@ export function createReportsConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.reports.v1.MsgSupportStandardReason": {
-      aminoType: "desmos/MsgSupportStandardReason",
+    [MsgSupportStandardReasonTypeUrl]: {
+      aminoType: MsgSupportStandardReasonAminoType,
       toAmino: (
         msg: MsgSupportStandardReason
       ): AminoMsgSupportStandardReason["value"] => ({
@@ -142,8 +157,8 @@ export function createReportsConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.reports.v1.MsgAddReason": {
-      aminoType: "desmos/MsgAddReason",
+    [MsgAddReasonTypeUrl]: {
+      aminoType: MsgAddReasonAminoType,
       toAmino: (msg: MsgAddReason): AminoMsgAddReason["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         title: msg.title,
@@ -157,8 +172,8 @@ export function createReportsConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.reports.v1.MsgRemoveReason": {
-      aminoType: "desmos/MsgRemoveReason",
+    [MsgRemoveReasonTypeUrl]: {
+      aminoType: MsgRemoveReasonAminoType,
       toAmino: (msg: MsgRemoveReason): AminoMsgRemoveReason["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         reason_id: msg.reasonId,

--- a/packages/core/src/aminomessages/reports/messages.ts
+++ b/packages/core/src/aminomessages/reports/messages.ts
@@ -1,8 +1,15 @@
 import { AminoMsg } from "@cosmjs/amino";
 import { AminoReportTarget } from "./types";
+import {
+  MsgAddReasonAminoType,
+  MsgCreateReportAminoType,
+  MsgDeleteReportAminoType,
+  MsgRemoveReasonAminoType,
+  MsgSupportStandardReasonAminoType,
+} from "../../const";
 
 export interface AminoMsgCreateReport extends AminoMsg {
-  readonly type: "desmos/MsgCreateReport";
+  readonly type: typeof MsgCreateReportAminoType;
   readonly value: {
     subspace_id: string;
     reasons_ids: number[];
@@ -13,7 +20,7 @@ export interface AminoMsgCreateReport extends AminoMsg {
 }
 
 export interface AminoMsgDeleteReport extends AminoMsg {
-  readonly type: "desmos/MsgDeleteReport";
+  readonly type: typeof MsgDeleteReportAminoType;
   readonly value: {
     subspace_id: string;
     report_id: string;
@@ -22,7 +29,7 @@ export interface AminoMsgDeleteReport extends AminoMsg {
 }
 
 export interface AminoMsgSupportStandardReason extends AminoMsg {
-  readonly type: "desmos/MsgSupportStandardReason";
+  readonly type: typeof MsgSupportStandardReasonAminoType;
   readonly value: {
     subspace_id: string;
     standard_reason_id: number;
@@ -31,7 +38,7 @@ export interface AminoMsgSupportStandardReason extends AminoMsg {
 }
 
 export interface AminoMsgAddReason extends AminoMsg {
-  readonly type: "desmos/MsgAddReason";
+  readonly type: typeof MsgAddReasonAminoType;
   readonly value: {
     subspace_id: string;
     title: string;
@@ -41,7 +48,7 @@ export interface AminoMsgAddReason extends AminoMsg {
 }
 
 export interface AminoMsgRemoveReason extends AminoMsg {
-  readonly type: "desmos/MsgRemoveReason";
+  readonly type: typeof MsgRemoveReasonAminoType;
   readonly value: {
     subspace_id: string;
     reason_id: number;

--- a/packages/core/src/aminomessages/reports/types.ts
+++ b/packages/core/src/aminomessages/reports/types.ts
@@ -1,16 +1,17 @@
 import { AminoMsg } from "@cosmjs/amino";
+import { PostTargetAminoType, UserTargetAminoType } from "../../const";
 
 export interface AminoReportTarget extends AminoMsg {}
 
 export interface AminoUserTarget extends AminoReportTarget {
-  readonly type: "desmos/UserTarget";
+  readonly type: typeof UserTargetAminoType;
   readonly value: {
     readonly user: string;
   };
 }
 
 export interface AminoPostTarget extends AminoReportTarget {
-  readonly type: "desmos/PostTarget";
+  readonly type: typeof PostTargetAminoType;
   readonly value: {
     readonly post_id: string;
   };

--- a/packages/core/src/aminomessages/subspaces/authorizations.ts
+++ b/packages/core/src/aminomessages/subspaces/authorizations.ts
@@ -3,7 +3,10 @@ import { Any } from "cosmjs-types/google/protobuf/any";
 import { GenericSubspaceAuthorization } from "@desmoslabs/desmjs-types/desmos/subspaces/v3/authz/authz";
 import Long from "long";
 import { AminoGenericSubspaceAuthorization } from "./messages";
-import { GenericSubspaceAuthorizationTypeUrl } from "../../const";
+import {
+  GenericSubspaceAuthorizationAminoType,
+  GenericSubspaceAuthorizationTypeUrl,
+} from "../../const";
 
 export function genericSubspaceAuthorizationToAny(
   authorization: GenericSubspaceAuthorization
@@ -16,8 +19,8 @@ export function genericSubspaceAuthorizationToAny(
 
 export function createSubspacesAuthorizationConverters(): AminoConverters {
   return {
-    "/desmos.subspaces.v3.authz.GenericSubspaceAuthorization": {
-      aminoType: "desmos/GenericSubspaceAuthorization",
+    [GenericSubspaceAuthorizationTypeUrl]: {
+      aminoType: GenericSubspaceAuthorizationAminoType,
       toAmino: (
         authorization: Any["value"]
       ): AminoGenericSubspaceAuthorization["value"] => {

--- a/packages/core/src/aminomessages/subspaces/converter.ts
+++ b/packages/core/src/aminomessages/subspaces/converter.ts
@@ -1,47 +1,79 @@
 import { AminoConverters } from "@cosmjs/stargate";
 import {
   MsgAddUserToUserGroup,
+  MsgCreateSection,
   MsgCreateSubspace,
   MsgCreateUserGroup,
+  MsgDeleteSection,
   MsgDeleteSubspace,
   MsgDeleteUserGroup,
+  MsgEditSection,
   MsgEditSubspace,
   MsgEditUserGroup,
+  MsgMoveSection,
+  MsgMoveUserGroup,
   MsgRemoveUserFromUserGroup,
   MsgSetUserGroupPermissions,
   MsgSetUserPermissions,
-  MsgCreateSection,
-  MsgEditSection,
-  MsgMoveSection,
-  MsgDeleteSection,
-  MsgMoveUserGroup,
 } from "@desmoslabs/desmjs-types/desmos/subspaces/v3/msgs";
 import Long from "long";
 import {
   AminoMsgAddUserToUserGroup,
+  AminoMsgCreateSection,
   AminoMsgCreateSubspace,
   AminoMsgCreateUserGroup,
+  AminoMsgDeleteSection,
   AminoMsgDeleteSubspace,
   AminoMsgDeleteUserGroup,
+  AminoMsgEditSection,
   AminoMsgEditSubspace,
   AminoMsgEditUserGroup,
+  AminoMsgMoveSection,
+  AminoMsgMoveUserGroup,
   AminoMsgRemoveUserFromUserGroup,
   AminoMsgSetUserGroupPermissions,
   AminoMsgSetUserPermissions,
-  AminoMsgCreateSection,
-  AminoMsgEditSection,
-  AminoMsgMoveSection,
-  AminoMsgDeleteSection,
-  AminoMsgMoveUserGroup,
 } from "./messages";
+import {
+  MsgAddUserToUserGroupAminoType,
+  MsgAddUserToUserGroupTypeUrl,
+  MsgCreateSectionAminoType,
+  MsgCreateSectionTypeUrl,
+  MsgCreateSubspaceAminoType,
+  MsgCreateSubspaceTypeUrl,
+  MsgCreateUserGroupAminoType,
+  MsgCreateUserGroupTypeUrl,
+  MsgDeleteSectionAminoType,
+  MsgDeleteSectionTypeUrl,
+  MsgDeleteSubspaceAminoType,
+  MsgDeleteSubspaceTypeUrl,
+  MsgDeleteUserGroupAminoType,
+  MsgDeleteUserGroupTypeUrl,
+  MsgEditSectionAminoType,
+  MsgEditSectionTypeUrl,
+  MsgEditSubspaceAminoType,
+  MsgEditSubspaceTypeUrl,
+  MsgEditUserGroupAminoType,
+  MsgEditUserGroupTypeUrl,
+  MsgMoveSectionAminoType,
+  MsgMoveSectionTypeUrl,
+  MsgMoveUserGroupAminoType,
+  MsgMoveUserGroupTypeUrl,
+  MsgRemoveUserFromUserGroupAminoType,
+  MsgRemoveUserFromUserGroupTypeUrl,
+  MsgSetUserGroupPermissionsAminoType,
+  MsgSetUserGroupPermissionsTypeUrl,
+  MsgSetUserPermissionsAminoType,
+  MsgSetUserPermissionsTypeUrl,
+} from "../../const";
 
 /**
  * Creates all the Amino converters for the subspaces messages.
  */
 export function createSubspacesConverters(): AminoConverters {
   return {
-    "/desmos.subspaces.v3.MsgCreateRelationships": {
-      aminoType: "desmos/MsgCreateRelationships",
+    [MsgCreateSubspaceTypeUrl]: {
+      aminoType: MsgCreateSubspaceAminoType,
       toAmino: (msg: MsgCreateSubspace): AminoMsgCreateSubspace["value"] => ({
         name: msg.name,
         description: msg.description,
@@ -57,8 +89,8 @@ export function createSubspacesConverters(): AminoConverters {
         owner: msg.owner,
       }),
     },
-    "/desmos.subspaces.v3.MsgEditSubspace": {
-      aminoType: "desmos/MsgEditSubspace",
+    [MsgEditSubspaceTypeUrl]: {
+      aminoType: MsgEditSubspaceAminoType,
       toAmino: (msg: MsgEditSubspace): AminoMsgEditSubspace["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         name: msg.name,
@@ -76,8 +108,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgDeleteSubspace": {
-      aminoType: "desmos/MsgDeleteSubspace",
+    [MsgDeleteSubspaceTypeUrl]: {
+      aminoType: MsgDeleteSubspaceAminoType,
       toAmino: (msg: MsgDeleteSubspace): AminoMsgDeleteSubspace["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         signer: msg.signer,
@@ -87,8 +119,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgCreateSection": {
-      aminoType: "desmos/MsgCreateSection",
+    [MsgCreateSectionTypeUrl]: {
+      aminoType: MsgCreateSectionAminoType,
       toAmino: (msg: MsgCreateSection): AminoMsgCreateSection["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         name: msg.name,
@@ -104,8 +136,8 @@ export function createSubspacesConverters(): AminoConverters {
         creator: msg.creator,
       }),
     },
-    "/desmos.subspaces.v3.MsgEditSection": {
-      aminoType: "desmos/MsgEditSection",
+    [MsgEditSectionTypeUrl]: {
+      aminoType: MsgEditSectionAminoType,
       toAmino: (msg: MsgEditSection): AminoMsgEditSection["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         section_id: msg.sectionId,
@@ -121,8 +153,8 @@ export function createSubspacesConverters(): AminoConverters {
         editor: msg.editor,
       }),
     },
-    "/desmos.subspaces.v3.MsgMoveSection": {
-      aminoType: "desmos/MsgMoveSection",
+    [MsgMoveSectionTypeUrl]: {
+      aminoType: MsgMoveSectionAminoType,
       toAmino: (msg: MsgMoveSection): AminoMsgMoveSection["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         section_id: msg.sectionId,
@@ -136,8 +168,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgDeleteSection": {
-      aminoType: "desmos/MsgDeleteSection",
+    [MsgDeleteSectionTypeUrl]: {
+      aminoType: MsgDeleteSectionAminoType,
       toAmino: (msg: MsgDeleteSection): AminoMsgDeleteSection["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         section_id: msg.sectionId,
@@ -149,8 +181,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgCreateUserGroup": {
-      aminoType: "desmos/MsgCreateUserGroup",
+    [MsgCreateUserGroupTypeUrl]: {
+      aminoType: MsgCreateUserGroupAminoType,
       toAmino: (msg: MsgCreateUserGroup): AminoMsgCreateUserGroup["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         section_id: msg.sectionId,
@@ -172,8 +204,8 @@ export function createSubspacesConverters(): AminoConverters {
         creator: msg.creator,
       }),
     },
-    "/desmos.subspaces.v3.MsgEditUserGroup": {
-      aminoType: "desmos/MsgEditUserGroup",
+    [MsgEditUserGroupTypeUrl]: {
+      aminoType: MsgEditUserGroupAminoType,
       toAmino: (msg: MsgEditUserGroup): AminoMsgEditUserGroup["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         group_id: msg.groupId,
@@ -189,8 +221,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgMoveUserGroup": {
-      aminoType: "desmos/MsgMoveUserGroup",
+    [MsgMoveUserGroupTypeUrl]: {
+      aminoType: MsgMoveUserGroupAminoType,
       toAmino: (msg: MsgMoveUserGroup): AminoMsgMoveUserGroup["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         group_id: msg.groupId,
@@ -204,8 +236,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgSetUserGroupPermissions": {
-      aminoType: "desmos/MsgSetUserGroupPermissions",
+    [MsgSetUserGroupPermissionsTypeUrl]: {
+      aminoType: MsgSetUserGroupPermissionsAminoType,
       toAmino: (
         msg: MsgSetUserGroupPermissions
       ): AminoMsgSetUserGroupPermissions["value"] => ({
@@ -223,8 +255,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgDeleteUserGroup": {
-      aminoType: "desmos/MsgDeleteUserGroup",
+    [MsgDeleteUserGroupTypeUrl]: {
+      aminoType: MsgDeleteUserGroupAminoType,
       toAmino: (msg: MsgDeleteUserGroup): AminoMsgDeleteUserGroup["value"] => ({
         subspace_id: msg.subspaceId.toString(),
         group_id: msg.groupId,
@@ -238,8 +270,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgAddUserToUserGroup": {
-      aminoType: "desmos/MsgAddUserToUserGroup",
+    [MsgAddUserToUserGroupTypeUrl]: {
+      aminoType: MsgAddUserToUserGroupAminoType,
       toAmino: (
         msg: MsgAddUserToUserGroup
       ): AminoMsgAddUserToUserGroup["value"] => ({
@@ -257,8 +289,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgRemoveUserFromUserGroup": {
-      aminoType: "desmos/MsgRemoveUserFromUserGroup",
+    [MsgRemoveUserFromUserGroupTypeUrl]: {
+      aminoType: MsgRemoveUserFromUserGroupAminoType,
       toAmino: (
         msg: MsgRemoveUserFromUserGroup
       ): AminoMsgRemoveUserFromUserGroup["value"] => ({
@@ -276,8 +308,8 @@ export function createSubspacesConverters(): AminoConverters {
         signer: msg.signer,
       }),
     },
-    "/desmos.subspaces.v3.MsgSetUserPermissions": {
-      aminoType: "desmos/MsgSetUserPermissions",
+    [MsgSetUserPermissionsTypeUrl]: {
+      aminoType: MsgSetUserPermissionsAminoType,
       toAmino: (
         msg: MsgSetUserPermissions
       ): AminoMsgSetUserPermissions["value"] => ({

--- a/packages/core/src/aminomessages/subspaces/messages.ts
+++ b/packages/core/src/aminomessages/subspaces/messages.ts
@@ -1,7 +1,25 @@
 import { AminoMsg } from "@cosmjs/amino";
+import {
+  GenericSubspaceAuthorizationAminoType,
+  MsgAddUserToUserGroupAminoType,
+  MsgCreateSectionAminoType,
+  MsgCreateSubspaceAminoType,
+  MsgCreateUserGroupAminoType,
+  MsgDeleteSectionAminoType,
+  MsgDeleteSubspaceAminoType,
+  MsgDeleteUserGroupAminoType,
+  MsgEditSectionAminoType,
+  MsgEditSubspaceAminoType,
+  MsgEditUserGroupAminoType,
+  MsgMoveSectionAminoType,
+  MsgMoveUserGroupAminoType,
+  MsgRemoveUserFromUserGroupAminoType,
+  MsgSetUserGroupPermissionsAminoType,
+  MsgSetUserPermissionsAminoType,
+} from "../../const";
 
 export interface AminoGenericSubspaceAuthorization extends AminoMsg {
-  readonly type: "desmos/GenericSubspaceAuthorization";
+  readonly type: typeof GenericSubspaceAuthorizationAminoType;
   readonly value: {
     subspaces_ids: string[];
     msg: string;
@@ -9,7 +27,7 @@ export interface AminoGenericSubspaceAuthorization extends AminoMsg {
 }
 
 export interface AminoMsgCreateSubspace extends AminoMsg {
-  readonly type: "desmos/MsgCreateSubspace";
+  readonly type: typeof MsgCreateSubspaceAminoType;
   readonly value: {
     name: string;
     description: string;
@@ -20,7 +38,7 @@ export interface AminoMsgCreateSubspace extends AminoMsg {
 }
 
 export interface AminoMsgEditSubspace extends AminoMsg {
-  readonly type: "desmos/MsgEditSubspace";
+  readonly type: typeof MsgEditSubspaceAminoType;
   readonly value: {
     subspace_id: string;
     name: string;
@@ -32,7 +50,7 @@ export interface AminoMsgEditSubspace extends AminoMsg {
 }
 
 export interface AminoMsgDeleteSubspace extends AminoMsg {
-  readonly type: "desmos/MsgDeleteSubspace";
+  readonly type: typeof MsgDeleteSubspaceAminoType;
   readonly value: {
     subspace_id: string;
     signer: string;
@@ -40,7 +58,7 @@ export interface AminoMsgDeleteSubspace extends AminoMsg {
 }
 
 export interface AminoMsgCreateSection extends AminoMsg {
-  readonly type: "desmos/MsgCreateSection";
+  readonly type: typeof MsgCreateSectionAminoType;
   readonly value: {
     subspace_id: string;
     name: string;
@@ -51,7 +69,7 @@ export interface AminoMsgCreateSection extends AminoMsg {
 }
 
 export interface AminoMsgEditSection extends AminoMsg {
-  readonly type: "desmos/MsgEditSection";
+  readonly type: typeof MsgEditSectionAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;
@@ -62,7 +80,7 @@ export interface AminoMsgEditSection extends AminoMsg {
 }
 
 export interface AminoMsgMoveSection extends AminoMsg {
-  readonly type: "desmos/MsgMoveSection";
+  readonly type: typeof MsgMoveSectionAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;
@@ -72,7 +90,7 @@ export interface AminoMsgMoveSection extends AminoMsg {
 }
 
 export interface AminoMsgDeleteSection extends AminoMsg {
-  readonly type: "desmos/MsgDeleteSection";
+  readonly type: typeof MsgDeleteSectionAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;
@@ -81,7 +99,7 @@ export interface AminoMsgDeleteSection extends AminoMsg {
 }
 
 export interface AminoMsgCreateUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgCreateUserGroup";
+  readonly type: typeof MsgCreateUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;
@@ -94,7 +112,7 @@ export interface AminoMsgCreateUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgEditUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgEditUserGroup";
+  readonly type: typeof MsgEditUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -105,7 +123,7 @@ export interface AminoMsgEditUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgMoveUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgMoveUserGroup";
+  readonly type: typeof MsgMoveUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -115,7 +133,7 @@ export interface AminoMsgMoveUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgSetUserGroupPermissions extends AminoMsg {
-  readonly type: "desmos/MsgSetUserGroupPermissions";
+  readonly type: typeof MsgSetUserGroupPermissionsAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -125,7 +143,7 @@ export interface AminoMsgSetUserGroupPermissions extends AminoMsg {
 }
 
 export interface AminoMsgDeleteUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgDeleteUserGroup";
+  readonly type: typeof MsgDeleteUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -134,7 +152,7 @@ export interface AminoMsgDeleteUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgAddUserToUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgAddUserToUserGroup";
+  readonly type: typeof MsgAddUserToUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -144,7 +162,7 @@ export interface AminoMsgAddUserToUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgRemoveUserFromUserGroup extends AminoMsg {
-  readonly type: "desmos/MsgRemoveUserFromUserGroup";
+  readonly type: typeof MsgRemoveUserFromUserGroupAminoType;
   readonly value: {
     subspace_id: string;
     group_id: number;
@@ -154,7 +172,7 @@ export interface AminoMsgRemoveUserFromUserGroup extends AminoMsg {
 }
 
 export interface AminoMsgSetUserPermissions extends AminoMsg {
-  readonly type: "desmos/MsgSetUserPermissions";
+  readonly type: typeof MsgSetUserPermissionsAminoType;
   readonly value: {
     subspace_id: string;
     section_id: number;

--- a/packages/core/src/const/cosmos/authz/index.ts
+++ b/packages/core/src/const/cosmos/authz/index.ts
@@ -1,5 +1,8 @@
 export const GenericAuthorizationTypeUrl =
   "/cosmos.authz.v1beta1.GenericAuthorization";
+export const GenericAuthorizationAminoType = "cosmos-sdk/GenericAuthorization";
 
 export const MsgGrantTypeUrl = "/cosmos.authz.v1beta1.MsgGrant";
+export const MsgGrantAminoTpe = "cosmos-sdk/MsgGrant";
 export const MsgRevokeTypeUrl = "/cosmos.authz.v1beta1.MsgRevoke";
+export const MsgRevokeAminoType = "cosmos-sdk/MsgRevoke";

--- a/packages/core/src/const/cosmos/bank/index.ts
+++ b/packages/core/src/const/cosmos/bank/index.ts
@@ -1,4 +1,5 @@
 export const SendAuthorizationTypeUrl =
   "/cosmos.bank.v1beta1.SendAuthorization";
+export const SendAuthorizationAminoType = "cosmos-sdk/SendAuthorization";
 
 export default SendAuthorizationTypeUrl;

--- a/packages/core/src/const/cosmos/feegrant/index.ts
+++ b/packages/core/src/const/cosmos/feegrant/index.ts
@@ -1,10 +1,18 @@
 export const BasicAllowanceTypeUrl = "/cosmos.feegrant.v1beta1.BasicAllowance";
+export const BasicAllowanceAminoType = "cosmos-sdk/BasicAllowance";
+
 export const PeriodicAllowanceTypeUrl =
   "/cosmos.feegrant.v1beta1.PeriodicAllowance";
+export const PeriodicAllowanceAminoType = "cosmos-sdk/PeriodicAllowance";
+
 export const AllowedMsgAllowanceTypeUrl =
   "/cosmos.feegrant.v1beta1.AllowedMsgAllowance";
+export const AllowedMsgAllowanceAminoType = "cosmos-sdk/AllowedMsgAllowance";
 
 export const MsgGrantAllowanceTypeUrl =
   "/cosmos.feegrant.v1beta1.MsgGrantAllowance";
+export const MsgGrantAllowanceAminoType = "cosmos-sdk/MsgGrantAllowance";
+
 export const MsgRevokeAllowanceTypeUrl =
   "/cosmos.feegrant.v1beta1.MsgRevokeAllowance";
+export const MsgRevokeAllowanceAminoType = "cosmos-sdk/MsgRevokeAllowance";

--- a/packages/core/src/const/cosmos/staking/index.ts
+++ b/packages/core/src/const/cosmos/staking/index.ts
@@ -1,4 +1,3 @@
 export const StakeAuthorizationTypeUrl =
   "/cosmos.bank.v1beta1.StakeAuthorization";
-
-export default StakeAuthorizationTypeUrl;
+export const StakeAuthorizationAminoType = "cosmos-sdk/StakeAuthorization";

--- a/packages/core/src/const/desmjs/index.ts
+++ b/packages/core/src/const/desmjs/index.ts
@@ -1,3 +1,4 @@
 export const MsgAuthenticateTypeUrl = "/desmjs.v1.MsgAuthenticate";
+export const MsgAuthenticateAminoType = "desmjs/MsgAuthenticate";
 
 export default MsgAuthenticateTypeUrl;

--- a/packages/core/src/const/posts/index.ts
+++ b/packages/core/src/const/posts/index.ts
@@ -1,11 +1,26 @@
 export const PollTypeUrl = "/desmos.posts.v2.Poll";
+export const PollAminoType = "desmos/Poll";
+
 export const MediaTypeUrl = "/desmos.posts.v2.Media";
+export const MediaAminoType = "desmos/Media";
 
 export const MsgCreatePostTypeUrl = "/desmos.posts.v2.MsgCreatePost";
+export const MsgCreatePostAminoType = "desmos/MsgCreatePost";
+
 export const MsgEditPostTypeUrl = "/desmos.posts.v2.MsgEditPost";
+export const MsgEditPostAminoType = "desmos/MsgEditPost";
+
 export const MsgDeletePostTypeUrl = "/desmos.posts.v2.MsgDeletePost";
+export const MsgDeletePostAminoType = "desmos/MsgDeletePost";
+
 export const MsgAddPostAttachmentTypeUrl =
   "/desmos.posts.v2.MsgAddPostAttachment";
+export const MsgAddPostAttachmentAminoType = "desmos/MsgAddPostAttachment";
+
 export const MsgRemovePostAttachmentTypeUrl =
   "/desmos.posts.v2.MsgRemovePostAttachment";
+export const MsgRemovePostAttachmentAminoType =
+  "desmos/MsgRemovePostAttachment";
+
 export const MsgAnswerPollTypeUrl = "/desmos.posts.v2.MsgAnswerPoll";
+export const MsgAnswerPollAminoType = "desmos/MsgAnswerPoll";

--- a/packages/core/src/const/profiles/index.ts
+++ b/packages/core/src/const/profiles/index.ts
@@ -1,25 +1,52 @@
 export const Bech32AddressTypeUrl = "/desmos.profiles.v3.Bech32Address";
+export const Bech32AddressAminoType = "desmos/Bech32Address";
 export const Base58AddressTypeUrl = "/desmos.profiles.v3.Base58Address";
+export const Base58AddressAminoType = "desmos/Base58Address";
 export const HexAddressTypeUrl = "/desmos.profiles.v3.HexAddress";
+export const HexAddressAminoType = "desmos/HexAddress";
 export const SingleSignatureTypeUrl = "/desmos.profiles.v3.SingleSignature";
+export const SingleSignatureAminoType = "desmos/SingleSignature";
 export const CosmosMultiSignatureTypeUrl =
   "/desmos.profiles.v3.CosmosMultiSignature";
+export const CosmosMultiSignatureAminoType = "desmos/CosmosMultiSignature";
+
+export const MsgSaveProfileTypeUrl = "/desmos.profiles.v3.MsgSaveProfile";
+export const MsgSaveProfileAminoType = "desmos/MsgSaveProfile";
+
+export const MsgDeleteProfileTypeUrl = "/desmos.profiles.v3.MsgDeleteProfile";
+export const MsgDeleteProfileAminoType = "desmos/MsgDeleteProfile";
+
+export const MsgRequestDTagTransferTypeUrl =
+  "/desmos.profiles.v3.MsgRequestDTagTransfer";
+export const MsgRequestDTagTransferAminoType = "desmos/MsgRequestDTagTransfer";
+
+export const MsgAcceptDTagTransferRequestTypeUrl =
+  "/desmos.profiles.v3.MsgAcceptDTagTransferRequest";
+export const MsgAcceptDTagTransferRequestAminoType =
+  "desmos/MsgAcceptDTagTransferRequest";
+
+export const MsgRefuseDTagTransferRequestTypeUrl =
+  "/desmos.profiles.v3.MsgRefuseDTagTransferRequest";
+export const MsgRefuseDTagTransferRequestAminoType =
+  "desmos/MsgRefuseDTagTransferRequest";
+
+export const MsgCancelDTagTransferRequestTypeUrl =
+  "/desmos.profiles.v3.MsgCancelDTagTransferRequest";
+export const MsgCancelDTagTransferRequestAminoType =
+  "desmos/MsgCancelDTagTransferRequest";
 
 export const MsgLinkApplicationTypeUrl =
   "/desmos.profiles.v3.MsgLinkApplication";
+export const MsgLinkApplicationAminoType = "desmos/MsgLinkApplication";
+
 export const MsgUnlinkApplicationTypeUrl =
   "/desmos.profiles.v3.MsgUnlinkApplication";
+export const MsgUnlinkApplicationAminoType = "desmos/MsgUnlinkApplication";
+
 export const MsgLinkChainAccountTypeUrl =
   "/desmos.profiles.v3.MsgLinkChainAccount";
+export const MsgLinkChainAccountAminoType = "desmos/MsgLinkChainAccount";
+
 export const MsgUnlinkChainAccountTypeUrl =
   "/desmos.profiles.v3.MsgUnlinkChainAccount";
-export const MsgRequestDTagTransferTypeUrl =
-  "/desmos.profiles.v3.MsgRequestDTagTransfer";
-export const MsgCancelDTagTransferRequestTypeUrl =
-  "/desmos.profiles.v3.MsgCancelDTagTransferRequest";
-export const MsgAcceptDTagTransferRequestTypeUrl =
-  "/desmos.profiles.v3.MsgAcceptDTagTransferRequest";
-export const MsgRefuseDTagTransferRequestTypeUrl =
-  "/desmos.profiles.v3.MsgRefuseDTagTransferRequest";
-export const MsgSaveProfileTypeUrl = "/desmos.profiles.v3.MsgSaveProfile";
-export const MsgDeleteProfileTypeUrl = "/desmos.profiles.v3.MsgDeleteProfile";
+export const MsgUnlinkChainAccountAminoType = "desmos/MsgUnlinkChainAccount";

--- a/packages/core/src/const/reactions/index.ts
+++ b/packages/core/src/const/reactions/index.ts
@@ -1,15 +1,33 @@
 export const RegisteredReactionValueTypeUrl =
   "/desmos.reactions.v1.RegisteredReactionValue";
+export const RegisteredReactionValueAminoType =
+  "desmos/RegisteredReactionValue";
+
 export const FreeTextValueTypeUrl = "/desmos.reactions.v1.FreeTextValue";
+export const FreeTextValueAminoType = "desmos/FreeTextValue";
 
 export const MsgAddReactionTypeUrl = "/desmos.reactions.v1.MsgAddReaction";
+export const MsgAddReactionAminoType = "desmos/MsgAddReaction";
+
 export const MsgRemoveReactionTypeUrl =
   "/desmos.reactions.v1.MsgRemoveReaction";
+export const MsgRemoveReactionAminoType = "desmos/MsgRemoveReaction";
+
 export const MsgAddRegisteredReactionTypeUrl =
   "/desmos.reactions.v1.MsgAddRegisteredReaction";
+export const MsgAddRegisteredReactionAminoType =
+  "desmos/MsgAddRegisteredReaction";
+
 export const MsgEditRegisteredReactionTypeUrl =
   "/desmos.reactions.v1.MsgEditRegisteredReaction";
+export const MsgEditRegisteredReactionAminoType =
+  "desmos/MsgEditRegisteredReaction";
+
 export const MsgRemoveRegisteredReactionTypeUrl =
   "/desmos.reactions.v1.MsgRemoveRegisteredReaction";
+export const MsgRemoveRegisteredReactionAminoType =
+  "desmos/MsgRemoveRegisteredReaction";
+
 export const MsgSetReactionsParamsTypeUrl =
   "/desmos.reactions.v1.MsgSetReactionsParams";
+export const MsgSetReactionsParamsAminoType = "desmos/MsgSetReactionsParams";

--- a/packages/core/src/const/relationships/index.ts
+++ b/packages/core/src/const/relationships/index.ts
@@ -1,6 +1,10 @@
 export const MsgCreateRelationshipTypeUrl =
   "/desmos.relationships.v1.MsgCreateRelationship";
+export const MsgCreateRelationshipAminoType = "desmos/MsgCreateRelationship";
 export const MsgDeleteRelationshipTypeUrl =
   "/desmos.relationships.v1.MsgDeleteRelationship";
+export const MsgDeleteRelationshipAminoType = "desmos/MsgDeleteRelationship";
 export const MsgBlockUserTypeUrl = "/desmos.relationships.v1.MsgBlockUser";
+export const MsgBlockUserAminoType = "desmos/MsgBlockUser";
 export const MsgUnblockUserTypeUrl = "/desmos.relationships.v1.MsgUnblockUser";
+export const MsgUnblockUserAminoType = "desmos/MsgUnblockUser";

--- a/packages/core/src/const/reports/index.ts
+++ b/packages/core/src/const/reports/index.ts
@@ -1,9 +1,17 @@
 export const UserTargetTypeUrl = "/desmos.reports.v1.UserTarget";
+export const UserTargetAminoType = "desmos/UserTarget";
 export const PostTargetTypeUrl = "/desmos.reports.v1.PostTarget";
+export const PostTargetAminoType = "desmos/PostTarget";
 
 export const MsgCreateReportTypeUrl = "/desmos.reports.v1.MsgCreateReport";
+export const MsgCreateReportAminoType = "desmos/MsgCreateReport";
 export const MsgDeleteReportTypeUrl = "/desmos.reports.v1.MsgDeleteReport";
+export const MsgDeleteReportAminoType = "desmos/MsgDeleteReport";
 export const MsgSupportStandardReasonTypeUrl =
   "/desmos.reports.v1.MsgSupportStandardReason";
+export const MsgSupportStandardReasonAminoType =
+  "desmos/MsgSupportStandardReason";
 export const MsgAddReasonTypeUrl = "/desmos.reports.v1.MsgAddReason";
+export const MsgAddReasonAminoType = "desmos/MsgAddReason";
 export const MsgRemoveReasonTypeUrl = "/desmos.reports.v1.MsgRemoveReason";
+export const MsgRemoveReasonAminoType = "desmos/MsgRemoveReason";

--- a/packages/core/src/const/subspaces/index.ts
+++ b/packages/core/src/const/subspaces/index.ts
@@ -1,26 +1,45 @@
 export const GenericSubspaceAuthorizationTypeUrl =
   "/desmos.subspaces.v3.authz.GenericSubspaceAuthorization";
+export const GenericSubspaceAuthorizationAminoType =
+  "desmos/GenericSubspaceAuthorization";
 
 export const MsgCreateSubspaceTypeUrl =
   "/desmos.subspaces.v3.MsgCreateSubspace";
+export const MsgCreateSubspaceAminoType = "desmos/MsgCreateSubspace";
 export const MsgEditSubspaceTypeUrl = "/desmos.subspaces.v3.MsgEditSubspace";
+export const MsgEditSubspaceAminoType = "desmos/MsgEditSubspace";
 export const MsgDeleteSubspaceTypeUrl =
   "/desmos.subspaces.v3.MsgDeleteSubspace";
+export const MsgDeleteSubspaceAminoType = "desmos/MsgDeleteSubspace";
 export const MsgCreateSectionTypeUrl = "/desmos.subspaces.v3.MsgCreateSection";
+export const MsgCreateSectionAminoType = "desmos/MsgCreateSection";
 export const MsgEditSectionTypeUrl = "/desmos.subspaces.v3.MsgEditSection";
+export const MsgEditSectionAminoType = "desmos/MsgEditSection";
 export const MsgMoveSectionTypeUrl = "/desmos.subspaces.v3.MsgMoveSection";
+export const MsgMoveSectionAminoType = "desmos/MsgMoveSection";
 export const MsgDeleteSectionTypeUrl = "/desmos.subspaces.v3.MsgDeleteSection";
+export const MsgDeleteSectionAminoType = "desmos/MsgDeleteSection";
 export const MsgCreateUserGroupTypeUrl =
   "/desmos.subspaces.v3.MsgCreateUserGroup";
+export const MsgCreateUserGroupAminoType = "desmos/MsgCreateUserGroup";
 export const MsgEditUserGroupTypeUrl = "/desmos.subspaces.v3.MsgEditUserGroup";
+export const MsgEditUserGroupAminoType = "desmos/MsgEditUserGroup";
 export const MsgMoveUserGroupTypeUrl = "/desmos.subspaces.v3.MsgMoveUserGroup";
+export const MsgMoveUserGroupAminoType = "desmos/MsgMoveUserGroup";
 export const MsgSetUserGroupPermissionsTypeUrl =
   "/desmos.subspaces.v3.MsgSetUserGroupPermissions";
+export const MsgSetUserGroupPermissionsAminoType =
+  "desmos/MsgSetUserGroupPermissions";
 export const MsgDeleteUserGroupTypeUrl =
   "/desmos.subspaces.v3.MsgDeleteUserGroup";
+export const MsgDeleteUserGroupAminoType = "desmos/MsgDeleteUserGroup";
 export const MsgAddUserToUserGroupTypeUrl =
   "/desmos.subspaces.v3.MsgAddUserToUserGroup";
+export const MsgAddUserToUserGroupAminoType = "desmos/MsgAddUserToUserGroup";
 export const MsgRemoveUserFromUserGroupTypeUrl =
   "/desmos.subspaces.v3.MsgRemoveUserFromUserGroup";
+export const MsgRemoveUserFromUserGroupAminoType =
+  "desmos/MsgRemoveUserFromUserGroup";
 export const MsgSetUserPermissionsTypeUrl =
   "/desmos.subspaces.v3.MsgSetUserPermissions";
+export const MsgSetUserPermissionsAminoType = "desmos/MsgSetUserPermissions";

--- a/packages/core/src/encodeobjects/cosmos.ts
+++ b/packages/core/src/encodeobjects/cosmos.ts
@@ -34,7 +34,7 @@ export function isMsgRevoke(
 }
 
 export interface MsgGrantAllowanceEncodeObject extends EncodeObject {
-  readonly typeUrl: "/cosmos.feegrant.v1beta1.MsgGrantAllowance";
+  readonly typeUrl: typeof MsgGrantAllowanceTypeUrl;
   readonly value: MsgGrantAllowance;
 }
 
@@ -48,7 +48,7 @@ export function isMsgGrantAllowance(
 }
 
 export interface MsgRevokeAllowanceEncodeObject extends EncodeObject {
-  readonly typeUrl: "/cosmos.feegrant.v1beta1.MsgRevokeAllowance";
+  readonly typeUrl: typeof MsgRevokeAllowanceTypeUrl;
   readonly value: MsgRevokeAllowance;
 }
 

--- a/packages/core/src/encodeobjects/demjs.ts
+++ b/packages/core/src/encodeobjects/demjs.ts
@@ -3,7 +3,7 @@ import { MsgAuthenticate } from "@desmoslabs/desmjs-types/desmjs/msgs";
 import { MsgAuthenticateTypeUrl } from "../const";
 
 export interface MsgAuthenticateEncodeObject extends EncodeObject {
-  typeUrl: "/desmjs.v1.MsgAuthenticate";
+  typeUrl: typeof MsgAuthenticateTypeUrl;
   readonly value: MsgAuthenticate;
 }
 

--- a/packages/core/src/encodeobjects/posts.ts
+++ b/packages/core/src/encodeobjects/posts.ts
@@ -17,7 +17,7 @@ import {
 } from "../const";
 
 export interface MsgCreatePostEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgCreatePost";
+  readonly typeUrl: typeof MsgCreatePostTypeUrl;
   readonly value: MsgCreatePost;
 }
 
@@ -30,7 +30,7 @@ export function isMsgCreatePostEncodeObject(
 }
 
 export interface MsgEditPostEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgEditPost";
+  readonly typeUrl: typeof MsgEditPostTypeUrl;
   readonly value: MsgEditPost;
 }
 
@@ -43,7 +43,7 @@ export function isMsgEditPostEncodeObject(
 }
 
 export interface MsgDeletePostEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgDeletePost";
+  readonly typeUrl: typeof MsgDeletePostTypeUrl;
   readonly value: MsgDeletePost;
 }
 
@@ -56,7 +56,7 @@ export function isMsgDeletePostEncodeObject(
 }
 
 export interface MsgAddPostAttachmentEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgAddPostAttachment";
+  readonly typeUrl: typeof MsgAddPostAttachmentTypeUrl;
   readonly value: MsgAddPostAttachment;
 }
 
@@ -70,7 +70,7 @@ export function isMsgAddPostAttachmentEncodeObject(
 }
 
 export interface MsgRemovePostAttachmentEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgRemovePostAttachment";
+  readonly typeUrl: typeof MsgRemovePostAttachmentTypeUrl;
   readonly value: MsgRemovePostAttachment;
 }
 
@@ -84,7 +84,7 @@ export function isMsgRemovePostAttachmentEncodeObject(
 }
 
 export interface MsgAnswerPollEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.posts.v2.MsgAnswerPoll";
+  readonly typeUrl: typeof MsgAnswerPollTypeUrl;
   readonly value: MsgAnswerPoll;
 }
 

--- a/packages/core/src/encodeobjects/profiles.ts
+++ b/packages/core/src/encodeobjects/profiles.ts
@@ -31,7 +31,7 @@ import {
 } from "../const";
 
 export interface MsgLinkApplicationEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgLinkApplication";
+  readonly typeUrl: typeof MsgLinkApplicationTypeUrl;
   readonly value: MsgLinkApplication;
 }
 
@@ -45,7 +45,7 @@ export function isMsgLinkApplicationEncodeObject(
 }
 
 export interface MsgUnlinkApplicationEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgUnlinkApplication";
+  readonly typeUrl: typeof MsgUnlinkApplicationTypeUrl;
   readonly value: MsgUnlinkApplication;
 }
 
@@ -59,7 +59,7 @@ export function isMsgUnlinkApplicationEncodeObject(
 }
 
 export interface MsgLinkChainAccountEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgLinkChainAccount";
+  readonly typeUrl: typeof MsgLinkChainAccountTypeUrl;
   readonly value: MsgLinkChainAccount;
 }
 
@@ -73,7 +73,7 @@ export function isMsgLinkChainAccountEncodeObject(
 }
 
 export interface MsgUnlinkChainAccountEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgUnlinkChainAccount";
+  readonly typeUrl: typeof MsgUnlinkChainAccountTypeUrl;
   readonly value: MsgUnlinkChainAccount;
 }
 
@@ -87,7 +87,7 @@ export function isMsgUnlinkChainAccountEncodeObject(
 }
 
 export interface MsgRequestDTagTransferEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgRequestDTagTransfer";
+  readonly typeUrl: typeof MsgRequestDTagTransferTypeUrl;
   readonly value: MsgRequestDTagTransfer;
 }
 
@@ -101,7 +101,7 @@ export function isMsgRequestDTagTransferEncodeObject(
 }
 
 export interface MsgCancelDTagTransferRequestEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgCancelDTagTransferRequest";
+  readonly typeUrl: typeof MsgCancelDTagTransferRequestTypeUrl;
   readonly value: MsgCancelDTagTransferRequest;
 }
 
@@ -115,7 +115,7 @@ export function isMsgCancelDTagTransferRequestEncodeObject(
 }
 
 export interface MsgAcceptDTagTransferRequestEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgAcceptDTagTransferRequest";
+  readonly typeUrl: typeof MsgAcceptDTagTransferRequestTypeUrl;
   readonly value: MsgAcceptDTagTransferRequest;
 }
 
@@ -129,7 +129,7 @@ export function isMsgAcceptDTagTransferRequestEncodeObject(
 }
 
 export interface MsgRefuseDTagTransferRequestEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgRefuseDTagTransferRequest";
+  readonly typeUrl: typeof MsgRefuseDTagTransferRequestTypeUrl;
   readonly value: MsgRefuseDTagTransferRequest;
 }
 
@@ -143,7 +143,7 @@ export function isMsgRefuseDTagTransferRequestEncodeObject(
 }
 
 export interface MsgSaveProfileEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgSaveProfile";
+  readonly typeUrl: typeof MsgSaveProfileTypeUrl;
   readonly value: MsgSaveProfile;
 }
 
@@ -157,7 +157,7 @@ export function isMsgSaveProfileEncodeObject(
 }
 
 export interface MsgDeleteProfileEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.profiles.v3.MsgDeleteProfile";
+  readonly typeUrl: typeof MsgDeleteProfileTypeUrl;
   readonly value: MsgDeleteProfile;
 }
 

--- a/packages/core/src/encodeobjects/reactions.ts
+++ b/packages/core/src/encodeobjects/reactions.ts
@@ -17,7 +17,7 @@ import {
 } from "../const";
 
 export interface MsgAddReactionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgAddReaction";
+  readonly typeUrl: typeof MsgAddReactionTypeUrl;
   readonly value: MsgAddReaction;
 }
 
@@ -31,7 +31,7 @@ export function isMsgAddReactionEncodeObject(
 }
 
 export interface MsgRemoveReactionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgRemoveReaction";
+  readonly typeUrl: typeof MsgRemoveReactionTypeUrl;
   readonly value: MsgRemoveReaction;
 }
 
@@ -45,7 +45,7 @@ export function isMsgRemoveReactionEncodeObject(
 }
 
 export interface MsgAddRegisteredReactionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgAddRegisteredReaction";
+  readonly typeUrl: typeof MsgAddRegisteredReactionTypeUrl;
   readonly value: MsgAddRegisteredReaction;
 }
 
@@ -59,7 +59,7 @@ export function isMsgAddRegisteredReactionEncodeObject(
 }
 
 export interface MsgEditRegisteredReactionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgEditRegisteredReaction";
+  readonly typeUrl: typeof MsgEditRegisteredReactionTypeUrl;
   readonly value: MsgEditRegisteredReaction;
 }
 
@@ -73,7 +73,7 @@ export function isMsgEditRegisteredReactionEncodeObject(
 }
 
 export interface MsgRemoveRegisteredReactionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgRemoveRegisteredReaction";
+  readonly typeUrl: typeof MsgRemoveRegisteredReactionTypeUrl;
   readonly value: MsgRemoveRegisteredReaction;
 }
 
@@ -87,7 +87,7 @@ export function isMsgRemoveRegisteredReactionEncodeObject(
 }
 
 export interface MsgSetReactionsParamsEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reactions.v1.MsgSetReactionsParams";
+  readonly typeUrl: typeof MsgSetReactionsParamsTypeUrl;
   readonly value: MsgSetReactionsParams;
 }
 

--- a/packages/core/src/encodeobjects/relationships.ts
+++ b/packages/core/src/encodeobjects/relationships.ts
@@ -13,7 +13,7 @@ import {
 } from "../const";
 
 export interface MsgCreateRelationshipEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.relationships.v1.MsgCreateRelationship";
+  readonly typeUrl: typeof MsgCreateRelationshipTypeUrl;
   readonly value: MsgCreateRelationship;
 }
 
@@ -27,7 +27,7 @@ export function isMsgCreateRelationshipEncodeObject(
 }
 
 export interface MsgDeleteRelationshipEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.relationships.v1.MsgDeleteRelationship";
+  readonly typeUrl: typeof MsgDeleteRelationshipTypeUrl;
   readonly value: MsgDeleteRelationship;
 }
 
@@ -41,7 +41,7 @@ export function isMsgDeleteRelationshipEncodeObject(
 }
 
 export interface MsgBlockUserEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.relationships.v1.MsgBlockUser";
+  readonly typeUrl: typeof MsgBlockUserTypeUrl;
   readonly value: MsgBlockUser;
 }
 
@@ -54,7 +54,7 @@ export function isMsgBlockUserEncodeObject(
 }
 
 export interface MsgUnblockUserEncodeObject extends EncodeObject {
-  typeUrl: "/desmos.relationships.v1.MsgUnblockUser";
+  readonly typeUrl: typeof MsgUnblockUserTypeUrl;
   readonly value: MsgUnblockUser;
 }
 

--- a/packages/core/src/encodeobjects/reports.ts
+++ b/packages/core/src/encodeobjects/reports.ts
@@ -15,7 +15,7 @@ import {
 } from "../const";
 
 export interface MsgCreateReportEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reports.v1.MsgCreateReport";
+  readonly typeUrl: typeof MsgCreateReportTypeUrl;
   readonly value: MsgCreateReport;
 }
 
@@ -29,7 +29,7 @@ export function isMsgCreateReportEncodeObject(
 }
 
 export interface MsgDeleteReportEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reports.v1.MsgDeleteReport";
+  readonly typeUrl: typeof MsgDeleteReportTypeUrl;
   readonly value: MsgDeleteReport;
 }
 
@@ -43,7 +43,7 @@ export function isMsgDeleteReportEncodeObject(
 }
 
 export interface MsgSupportStandardReasonEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reports.v1.MsgSupportStandardReason";
+  readonly typeUrl: typeof MsgSupportStandardReasonTypeUrl;
   readonly value: MsgSupportStandardReason;
 }
 
@@ -57,7 +57,7 @@ export function isMsgSupportStandardReasonEncodeObject(
 }
 
 export interface MsgAddReasonEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reports.v1.MsgAddReason";
+  readonly typeUrl: typeof MsgAddReasonTypeUrl;
   readonly value: MsgAddReason;
 }
 
@@ -70,7 +70,7 @@ export function isMsgAddReasonEncodeObject(
 }
 
 export interface MsgRemoveReasonEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.reports.v1.MsgRemoveReason";
+  readonly typeUrl: typeof MsgRemoveReasonTypeUrl;
   readonly value: MsgRemoveReason;
 }
 

--- a/packages/core/src/encodeobjects/subspaces.ts
+++ b/packages/core/src/encodeobjects/subspaces.ts
@@ -1,20 +1,20 @@
 import { EncodeObject } from "@cosmjs/proto-signing";
 import {
   MsgAddUserToUserGroup,
+  MsgCreateSection,
   MsgCreateSubspace,
   MsgCreateUserGroup,
+  MsgDeleteSection,
   MsgDeleteSubspace,
   MsgDeleteUserGroup,
+  MsgEditSection,
   MsgEditSubspace,
   MsgEditUserGroup,
+  MsgMoveSection,
+  MsgMoveUserGroup,
   MsgRemoveUserFromUserGroup,
   MsgSetUserGroupPermissions,
   MsgSetUserPermissions,
-  MsgCreateSection,
-  MsgDeleteSection,
-  MsgEditSection,
-  MsgMoveSection,
-  MsgMoveUserGroup,
 } from "@desmoslabs/desmjs-types/desmos/subspaces/v3/msgs";
 import {
   MsgAddUserToUserGroupTypeUrl,
@@ -35,7 +35,7 @@ import {
 } from "../const";
 
 export interface MsgCreateSubspaceEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgCreateSubspace";
+  readonly typeUrl: typeof MsgCreateSubspaceTypeUrl;
   readonly value: MsgCreateSubspace;
 }
 
@@ -49,7 +49,7 @@ export function isMsgCreateSubspaceEncodeObject(
 }
 
 export interface MsgEditSubspaceEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgEditSubspace";
+  readonly typeUrl: typeof MsgEditSubspaceTypeUrl;
   readonly value: MsgEditSubspace;
 }
 
@@ -63,7 +63,7 @@ export function isMsgEditSubspaceEncodeObject(
 }
 
 export interface MsgDeleteSubspaceEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgDeleteSubspace";
+  readonly typeUrl: typeof MsgDeleteSubspaceTypeUrl;
   readonly value: MsgDeleteSubspace;
 }
 
@@ -77,7 +77,7 @@ export function isMsgDeleteSubspaceEncodeObject(
 }
 
 export interface MsgCreateSectionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgCreateSection";
+  readonly typeUrl: typeof MsgCreateSectionTypeUrl;
   readonly value: MsgCreateSection;
 }
 
@@ -91,7 +91,7 @@ export function isMsgCreateSectionEncodeObject(
 }
 
 export interface MsgEditSectionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgEditSection";
+  readonly typeUrl: typeof MsgEditSectionTypeUrl;
   readonly value: MsgEditSection;
 }
 
@@ -105,7 +105,7 @@ export function isMsgEditSectionEncodeObject(
 }
 
 export interface MsgMoveSectionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgMoveSection";
+  readonly typeUrl: typeof MsgMoveSectionTypeUrl;
   readonly value: MsgMoveSection;
 }
 
@@ -119,7 +119,7 @@ export function isMsgMoveSectionEncodeObject(
 }
 
 export interface MsgDeleteSectionEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgDeleteSection";
+  readonly typeUrl: typeof MsgDeleteSectionTypeUrl;
   readonly value: MsgDeleteSection;
 }
 
@@ -133,7 +133,7 @@ export function isMsgDeleteSectionEncodeObject(
 }
 
 export interface MsgCreateUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgCreateUserGroup";
+  readonly typeUrl: typeof MsgCreateUserGroupTypeUrl;
   readonly value: MsgCreateUserGroup;
 }
 
@@ -147,7 +147,7 @@ export function isMsgCreateUserGroupEncodeObject(
 }
 
 export interface MsgEditUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgEditUserGroup";
+  readonly typeUrl: typeof MsgEditUserGroupTypeUrl;
   readonly value: MsgEditUserGroup;
 }
 
@@ -161,7 +161,7 @@ export function isMsgEditUserGroupEncodeObject(
 }
 
 export interface MsgMoveUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgMoveUserGroup";
+  readonly typeUrl: typeof MsgMoveUserGroupTypeUrl;
   readonly value: MsgMoveUserGroup;
 }
 
@@ -175,7 +175,7 @@ export function isMsgMoveUserGroupEncodeObject(
 }
 
 export interface MsgSetUserGroupPermissionsEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgSetUserGroupPermissions";
+  readonly typeUrl: typeof MsgSetUserGroupPermissionsTypeUrl;
   readonly value: MsgSetUserGroupPermissions;
 }
 
@@ -189,7 +189,7 @@ export function isMsgSetUserGroupPermissionsEncodeObject(
 }
 
 export interface MsgDeleteUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgDeleteUserGroup";
+  readonly typeUrl: typeof MsgDeleteUserGroupTypeUrl;
   readonly value: MsgDeleteUserGroup;
 }
 
@@ -203,7 +203,7 @@ export function isMsgDeleteUserGroupEncodeObject(
 }
 
 export interface MsgAddUserToUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgAddUserToUserGroup";
+  readonly typeUrl: typeof MsgAddUserToUserGroupTypeUrl;
   readonly value: MsgAddUserToUserGroup;
 }
 
@@ -217,7 +217,7 @@ export function isMsgAddUserToUserGroupEncodeObject(
 }
 
 export interface MsgRemoveUserFromUserGroupEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgRemoveUserFromUserGroup";
+  readonly typeUrl: typeof MsgRemoveUserFromUserGroupTypeUrl;
   readonly value: MsgRemoveUserFromUserGroup;
 }
 
@@ -231,7 +231,7 @@ export function isMsgRemoveUserFromUserGroupEncodeObject(
 }
 
 export interface MsgSetUserPermissionsEncodeObject extends EncodeObject {
-  readonly typeUrl: "/desmos.subspaces.v3.MsgSetUserPermissions";
+  readonly typeUrl: typeof MsgSetUserPermissionsTypeUrl;
   readonly value: MsgSetUserPermissions;
 }
 


### PR DESCRIPTION
## Description


This PR replaces all the Protobuf and Amino type strings with the appropriate const variables.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
