### PR TITLE
feat: allow to simulate a tx with a DesmosClient without signer

### DIFF
--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -61,6 +61,11 @@ import { createDesmosTypes, desmosRegistryTypes } from "./aminomessages";
 import { SignatureResult } from "./signatureresult";
 import { PublicKey } from "./types/pubkey";
 
+export interface SimulateOptions {
+  publicKey?: PublicKey;
+  memo?: string;
+}
+
 function createDefaultRegistry(): Registry {
   return new Registry(desmosRegistryTypes);
 }
@@ -345,7 +350,7 @@ export class DesmosClient extends SigningCosmWasmClient {
     const txFee =
       fee !== "auto"
         ? fee
-        : await this.estimateTxFee(signerAddress, messages, memo);
+        : await this.estimateTxFee(signerAddress, messages, { memo });
 
     // Build the signer data
     const signerData =
@@ -372,23 +377,20 @@ export class DesmosClient extends SigningCosmWasmClient {
   }
 
   /**
-   * Function to simulate the required gas to perform a transaction.
+   * Function to estimate the required gas to perform a transaction.
    * @param signerAddress - Address of who is performing the transaction.
    * @param messages - Messages of the transaction to simulate.
-   * @param memo - Transaction memo.
-   * @param publicKey - Optional public key that can be passed to avoid
-   * querying the signer to obtain the public key associated to signerAddress.
+   * @param options - Extra transaction simulation options.
    */
-  public override async simulate(
+  public async estimateTxGas(
     signerAddress: string,
     messages: readonly EncodeObject[],
-    memo: string | undefined,
-    publicKey?: PublicKey
+    options?: SimulateOptions
   ): Promise<number> {
     const anyMsgs = messages.map((m) => this.registry.encodeAsAny(m));
 
     let pubKey: Secp256k1Pubkey;
-    if (publicKey === undefined) {
+    if (options?.publicKey === undefined) {
       const accountFromSigner = (await this.txSigner.getAccounts()).find(
         (account) => account.address === signerAddress
       );
@@ -397,13 +399,13 @@ export class DesmosClient extends SigningCosmWasmClient {
       }
       pubKey = encodeSecp256k1Pubkey(accountFromSigner.pubkey);
     } else {
-      pubKey = encodeSecp256k1Pubkey(publicKey.bytes);
+      pubKey = encodeSecp256k1Pubkey(options.publicKey.bytes);
     }
 
     const { sequence } = await this.getSequence(signerAddress);
     const { gasInfo } = await this.forceGetQueryClient().tx.simulate(
       anyMsgs,
-      memo,
+      options?.memo,
       pubKey,
       sequence
     );
@@ -415,15 +417,12 @@ export class DesmosClient extends SigningCosmWasmClient {
    * Function to estimate the fees required to perform a transaction.
    * @param signerAddress - Address of who is performing the transaction.
    * @param messages - Messages of the transaction to simulate.
-   * @param memo - Transaction memo.
-   * @param publicKey - Optional public key that can be passed to avoid
-   * querying the signer to obtain the public key associated to signerAddress.
+   * @param options - Extra transaction simulation options.
    */
   public async estimateTxFee(
     signerAddress: string,
     messages: readonly EncodeObject[],
-    memo: string,
-    publicKey?: PublicKey
+    options?: SimulateOptions
   ): Promise<StdFee> {
     const { gasPrice } = this.options;
     if (!gasPrice) {
@@ -432,11 +431,10 @@ export class DesmosClient extends SigningCosmWasmClient {
       );
     }
 
-    const estimated = await this.simulate(
+    const estimated = await this.estimateTxGas(
       signerAddress,
       messages,
-      memo,
-      publicKey
+      options
     );
     const gasAdjustment = this.options.gasAdjustment || 1.5;
     const gas = Math.ceil(estimated * gasAdjustment);

--- a/packages/core/src/types/pubkey.ts
+++ b/packages/core/src/types/pubkey.ts
@@ -1,0 +1,15 @@
+import { Algo } from "@cosmjs/amino/build/signer";
+
+/**
+ * Interface that represents a public key.
+ */
+export interface PublicKey {
+  /**
+   * Public key type.
+   */
+  readonly algo: Algo;
+  /**
+   * Public key bytes.
+   */
+  readonly bytes: Uint8Array;
+}


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR implements the possibility to estimate the transaction fees  from a `DesmosClient` that has been initialized with the `DesmosClient.connect` function.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
