### PR TITLE
feat: add methods to broadcast a transaction in async, sync or block mode

### DIFF
--- a/packages/core/src/desmosclient.integration.spec.ts
+++ b/packages/core/src/desmosclient.integration.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { fromBase64, fromUtf8, toHex } from "@cosmjs/encoding";
 import { Profile } from "@desmoslabs/desmjs-types/desmos/profiles/v3/models_profile";
 import { MsgSendEncodeObject, SignerData, StdFee } from "@cosmjs/stargate";
@@ -7,7 +8,7 @@ import {
   ChainConfig,
   Proof,
   SignatureValueType,
-  SingleSignature,
+  SingleSignature
 } from "@desmoslabs/desmjs-types/desmos/profiles/v3/models_chain_links";
 import { Any } from "@desmoslabs/desmjs-types/google/protobuf/any";
 import { MsgLinkChainAccount } from "@desmoslabs/desmjs-types/desmos/profiles/v3/msgs_chain_links";
@@ -17,18 +18,13 @@ import Long from "long";
 import { sleep } from "@cosmjs/utils";
 import { DesmosClient } from "./desmosclient";
 import { OfflineSignerAdapter, Signer, SigningMode } from "./signers";
-import {
-  defaultGasPrice,
-  TEST_CHAIN_URL,
-  testUser1,
-  testUser2,
-} from "./testutils";
+import { defaultGasPrice, TEST_CHAIN_URL, testUser1, testUser2 } from "./testutils";
 import {
   getPubKeyBytes,
   getPubKeyRawBytes,
   getSignatureBytes,
   getSignedBytes,
-  SignatureResult,
+  SignatureResult
 } from "./signatureresult";
 import {
   MsgAddReactionEncodeObject,
@@ -40,12 +36,9 @@ import {
   MsgCreateSubspaceEncodeObject,
   MsgLinkChainAccountEncodeObject,
   MsgMultiSendEncodeObject,
-  MsgSaveProfileEncodeObject,
+  MsgSaveProfileEncodeObject
 } from "./encodeobjects";
-import {
-  bech32AddressToAny,
-  singleSignatureToAny,
-} from "./aminomessages/profiles";
+import { bech32AddressToAny, singleSignatureToAny } from "./aminomessages/profiles";
 import { postTargetToAny } from "./aminomessages/reports";
 import { registeredReactionValueToAny } from "./aminomessages/reactions";
 import {
@@ -57,7 +50,7 @@ import {
   MsgCreateReportTypeUrl,
   MsgCreateSubspaceTypeUrl,
   MsgMultiSendTypeUrl,
-  MsgSaveProfileTypeUrl,
+  MsgSaveProfileTypeUrl
 } from "./const";
 import MsgAuthenticateTypeUrl from "./const/desmjs";
 

--- a/packages/core/src/types/responses.ts
+++ b/packages/core/src/types/responses.ts
@@ -1,0 +1,54 @@
+import { tendermint34, tendermint37 } from "@cosmjs/tendermint-rpc";
+
+/**
+ * Mode in which a transaction can be broadcast.
+ */
+export enum BroadcastMode {
+  /**
+   * Broadcast transaction to mempool and do not wait for response.
+   */
+  Async = "async",
+  /**
+   * Broadcast transaction to mempool and wait for response.
+   */
+  Sync = "sync",
+  /**
+   * Broadcast transaction to mempool and wait that is included in a block.
+   */
+  Block = "block",
+}
+
+/**
+ * Represents a response to a async broadcast request.
+ */
+export interface AsyncBroadcastResponse {
+  readonly type: BroadcastMode.Async;
+  readonly hash: string;
+}
+
+/**
+ * Represents a response to a sync broadcast request.
+ */
+export interface SyncBroadcastResponse {
+  readonly type: BroadcastMode.Sync;
+  readonly hash: string;
+}
+
+/**
+ * Represents a response to a block broadcast request.
+ */
+export interface BlockBroadcastResponse {
+  readonly type: BroadcastMode.Block;
+  readonly height: number;
+  readonly hash: string;
+  readonly checkTx: tendermint34.TxData | tendermint37.TxData;
+  readonly deliverTx?: tendermint34.TxData | tendermint37.TxData;
+}
+
+/**
+ * Union of all responses to a broadcast request.
+ */
+export type BroadcastResponse =
+  | SyncBroadcastResponse
+  | AsyncBroadcastResponse
+  | BlockBroadcastResponse;


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds some methods to `DesmosClient` to broadcast a transaction in those following modes:
1. Async: Broadcast tx to the mempool;
2. Sync: Broadcast tx to the mempool and wait for the chain result that the transaction is valid;
3. Block: Broadcast tx to the mempool and wait that is included in a block.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
