### PR TITLE
fix: use gas adjustment when calling `signAndBroadcast`

### DIFF
--- a/packages/core/src/desmosclient.integration.spec.ts
+++ b/packages/core/src/desmosclient.integration.spec.ts
@@ -224,7 +224,7 @@ describe("DesmosClient", () => {
         externalSigner,
         {
           gasPrice: defaultGasPrice,
-          gasAdjustment: 1.2,
+          gasAdjustment: 1.3,
         }
       );
       const externalAccounts = await externalSigner.getAccounts();
@@ -240,7 +240,7 @@ describe("DesmosClient", () => {
         profileSigner,
         {
           gasPrice: defaultGasPrice,
-          gasAdjustment: 1.2,
+          gasAdjustment: 1.3,
         }
       );
       const profileAccounts = await profileSigner.getAccounts();

--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -188,7 +188,7 @@ export class DesmosClient extends SigningCosmWasmClient {
       );
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
       const multiplier =
-        typeof fee === "number" ? fee : this.options.gasAdjustment || 1.3;
+        typeof fee === "number" ? fee : this.options.gasAdjustment || 1.5;
       usedFee = calculateFee(
         Math.round(gasEstimation * multiplier),
         this.options.gasPrice

--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -174,20 +174,36 @@ export class DesmosClient extends SigningCosmWasmClient {
     return new DesmosClient(tmClient, options, signer);
   }
 
-  override async signAndBroadcast(signerAddress: string, messages: readonly EncodeObject[], fee: StdFee | "auto" | number, memo?: string): Promise<DeliverTxResponse> {
+  override async signAndBroadcast(
+    signerAddress: string,
+    messages: readonly EncodeObject[],
+    fee: StdFee | "auto" | number,
+    memo?: string
+  ): Promise<DeliverTxResponse> {
     let usedFee: StdFee;
-    if (fee == "auto" || typeof fee === "number") {
-      assertDefined(this.options.gasPrice, "Gas price must be set in the client options when auto gas is used.");
+    if (fee === "auto" || typeof fee === "number") {
+      assertDefined(
+        this.options.gasPrice,
+        "Gas price must be set in the client options when auto gas is used."
+      );
       const gasEstimation = await this.simulate(signerAddress, messages, memo);
-      const multiplier = typeof fee === "number" ? fee : this.options.gasAdjustment || 1.3;
-      usedFee = calculateFee(Math.round(gasEstimation * multiplier), this.options.gasPrice);
+      const multiplier =
+        typeof fee === "number" ? fee : this.options.gasAdjustment || 1.3;
+      usedFee = calculateFee(
+        Math.round(gasEstimation * multiplier),
+        this.options.gasPrice
+      );
     } else {
       usedFee = fee;
     }
     const txRaw = await this.sign(signerAddress, messages, usedFee, memo);
     const txBytes = TxRaw.encode(txRaw).finish();
-    return this.broadcastTx(txBytes, this.broadcastTimeoutMs, this.broadcastPollIntervalMs);
-  };
+    return this.broadcastTx(
+      txBytes,
+      this.broadcastTimeoutMs,
+      this.broadcastPollIntervalMs
+    );
+  }
 
   /**
    * Creates a client in offline mode.


### PR DESCRIPTION
## Description

Closes: #XXXX
This PR makes  `DesmosClient` use custom gas adjustment when calling `signAndBroadcast` instead of the fixed adjustment 1.3 by `cosmjs` as follows.

https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/signingstargateclient.ts#L319

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
