### PR TITLE
fix: add missing feegranter parameter to signAndBroadcast

### DIFF
--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -159,7 +159,8 @@ export class DesmosClient extends SigningCosmWasmClient {
     signerAddress: string,
     messages: readonly EncodeObject[],
     fee: StdFee | "auto" | number,
-    memo?: string
+    memo?: string,
+    feeGranter?: string,
   ): Promise<DeliverTxResponse> {
     let usedFee: StdFee;
     if (fee === "auto" || typeof fee === "number") {
@@ -177,7 +178,7 @@ export class DesmosClient extends SigningCosmWasmClient {
     } else {
       usedFee = fee;
     }
-    const txRaw = await this.sign(signerAddress, messages, usedFee, memo);
+    const txRaw = await this.sign(signerAddress, messages, usedFee, memo, feeGranter);
     const txBytes = TxRaw.encode(txRaw).finish();
     return this.broadcastTx(
       txBytes,
@@ -311,11 +312,13 @@ export class DesmosClient extends SigningCosmWasmClient {
     messages: readonly EncodeObject[],
     fee: StdFee | "auto",
     memo?: string,
+    feeGranter?: string,
     explicitSignerData?: SignerData
   ): Promise<TxRaw> {
     const result = await this.signTx(signerAddress, messages, {
       fee,
       memo,
+      feeGranter,
       signerData: explicitSignerData,
     });
     return result.txRaw;

--- a/packages/core/src/desmosclient.ts
+++ b/packages/core/src/desmosclient.ts
@@ -160,7 +160,7 @@ export class DesmosClient extends SigningCosmWasmClient {
     messages: readonly EncodeObject[],
     fee: StdFee | "auto" | number,
     memo?: string,
-    feeGranter?: string,
+    feeGranter?: string
   ): Promise<DeliverTxResponse> {
     let usedFee: StdFee;
     if (fee === "auto" || typeof fee === "number") {
@@ -312,7 +312,7 @@ export class DesmosClient extends SigningCosmWasmClient {
     messages: readonly EncodeObject[],
     fee: StdFee | "auto",
     memo?: string,
-    feeGranter?: string,
+    feeGranter?: string
     explicitSignerData?: SignerData
   ): Promise<TxRaw> {
     const result = await this.signTx(signerAddress, messages, {


### PR DESCRIPTION
## Description

Closes: #XXXX

Currently, `feeGranter` parameter is missing inside `signAndBroadcast` function, so it is difficult to add `feeGranter` field to the sending transaction. To allow the feegrant features, the solution is enabling `feeGranter` as a parameter.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
