### PR TITLE
feat(walletconnect-v2): cache the AccountData associated to a session

### DIFF
--- a/packages/walletconnect-v2/.gitignore
+++ b/packages/walletconnect-v2/.gitignore
@@ -1,0 +1,2 @@
+# Ignore node-localstorage directory
+scratch/

--- a/packages/walletconnect-v2/package.json
+++ b/packages/walletconnect-v2/package.json
@@ -54,6 +54,7 @@
     "dotenv": "^16.3.1",
     "jest": "^29.7.0",
     "lokijs": "^1.5.12",
+    "node-localstorage": "^3.0.5",
     "ts-jest": "^29.1.1",
     "typescript": "^4.9.5"
   }

--- a/packages/walletconnect-v2/src/sessioncache.ts
+++ b/packages/walletconnect-v2/src/sessioncache.ts
@@ -1,0 +1,111 @@
+import { AccountData } from "@cosmjs/amino";
+import { fromHex, toHex } from "@cosmjs/encoding";
+import { Algo } from "@cosmjs/proto-signing";
+
+const SESSION_CACHE_KEY = "desmos-walletconnect-sessions";
+
+interface SerializedAccountData {
+  readonly address: string;
+  readonly algo: Algo;
+  readonly hexPubkey: string;
+}
+
+/**
+ * Class to cache the user's AccountData associated to a WalletConnect session topic.
+ */
+class WalletConnectSessionCache {
+  /**
+   * Record where we store the AccountData associated to a WalletConnect session topic.
+   */
+  private cachedSessions: Record<string, AccountData[]>;
+
+  constructor() {
+    this.cachedSessions = this.loadCache();
+  }
+
+  /**
+   * Stores the cached sessions in the local storage.
+   */
+  private storeCache() {
+    const serializedData: Record<string, SerializedAccountData[]> = {};
+    Object.keys(this.cachedSessions).forEach((key) => {
+      serializedData[key] = this.cachedSessions[key].map((account) => ({
+        address: account.address,
+        algo: account.algo,
+        hexPubkey: toHex(account.pubkey),
+      }));
+    });
+
+    localStorage.setItem(SESSION_CACHE_KEY, JSON.stringify(serializedData));
+  }
+
+  /**
+   * Loads the cached sessions from the local storage.
+   */
+  private loadCache(): Record<string, AccountData[]> {
+    try {
+      const cachedSessions = localStorage.getItem(SESSION_CACHE_KEY);
+      if (!cachedSessions) {
+        return {};
+      }
+
+      const data = JSON.parse(cachedSessions);
+      if (typeof data === "object") {
+        const serializedData = data as Record<string, SerializedAccountData[]>;
+        const accountData: Record<string, AccountData[]> = {};
+        Object.keys(serializedData).forEach((key) => {
+          accountData[key] = serializedData[key].map((account) => ({
+            algo: account.algo,
+            pubkey: fromHex(account.hexPubkey),
+            address: account.address,
+          }));
+        });
+        return accountData;
+      }
+      // eslint-disable-next-line no-console
+      console.error("[desmjs-WalletConnect] Invalid data in session cache");
+      return {};
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error("[desmjs-WalletConnect] Failed to load session cache", e);
+      return {};
+    }
+  }
+
+  /**
+   * Stores the account data associated to a WalletConnect session topic.
+   * @param sessionTopic - WalletConnect session topic.
+   * @param accountData - Account data.
+   */
+  addAccountData(sessionTopic: string, accountData: AccountData[]) {
+    this.cachedSessions[sessionTopic] = accountData;
+    this.storeCache();
+  }
+
+  /**
+   * Retrieves the account data associated to a WalletConnect session topic.
+   * @param sessionId - WalletConnect session topic.
+   */
+  getAccountData(sessionId: string): AccountData[] | undefined {
+    return this.cachedSessions[sessionId];
+  }
+
+  /**
+   * Removes the account data associated to a WalletConnect session topic from the cache.
+   * @param sessionId - WalletConnect session topic.
+   */
+  removeAccountData(sessionId: string) {
+    delete this.cachedSessions[sessionId];
+    this.storeCache();
+  }
+
+  /**
+   * Clears all the cached data.
+   */
+  clear() {
+    this.cachedSessions = {};
+    this.storeCache();
+  }
+}
+
+export default WalletConnectSessionCache;

--- a/packages/walletconnect-v2/src/signer.unit.spec.ts
+++ b/packages/walletconnect-v2/src/signer.unit.spec.ts
@@ -22,6 +22,13 @@ import {
 import { QrCodeModalController, WalletConnectSigner } from "./signer";
 import { CosmosRPCMethods } from "./types";
 
+// Polyfill LocalStorage required from the WalletConnect session cache.
+if (typeof localStorage === "undefined" || localStorage === null) {
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+  const { LocalStorage } = require("node-localstorage");
+  global.localStorage = new LocalStorage("./scratch");
+}
+
 class MockQrCodeModalController implements QrCodeModalController {
   private _closed: boolean;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4595,6 +4595,7 @@ __metadata:
     jest: ^29.7.0
     lokijs: ^1.5.12
     long: ^4.0.0
+    node-localstorage: ^3.0.5
     ts-jest: ^29.1.1
     typescript: ^4.9.5
   languageName: unknown
@@ -17938,6 +17939,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-localstorage@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "node-localstorage@npm:3.0.5"
+  dependencies:
+    write-file-atomic: ^5.0.1
+  checksum: 222b70df7965f31d6ec687aeecd653d8a94c4faeb77eaaa16970faae63a03ddb12a5787bbf1ac6de6cd5f513e5c3a24f19f84fd892f141922f006bc6754e7be9
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.12, node-releases@npm:^2.0.13":
   version: 2.0.13
   resolution: "node-releases@npm:2.0.13"
@@ -20998,6 +21008,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
+  languageName: node
+  linkType: hard
+
 "sirv@npm:^1.0.7":
   version: 1.0.19
   resolution: "sirv@npm:1.0.19"
@@ -23419,6 +23436,16 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.7
   checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
+  languageName: node
+  linkType: hard
+
+"write-file-atomic@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "write-file-atomic@npm:5.0.1"
+  dependencies:
+    imurmurhash: ^0.1.4
+    signal-exit: ^4.0.1
+  checksum: 8dbb0e2512c2f72ccc20ccedab9986c7d02d04039ed6e8780c987dc4940b793339c50172a1008eed7747001bfacc0ca47562668a069a7506c46c77d7ba3926a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Closes: SDK-70

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds a cache to store the `AccountData` associated with a WalletConnect session, allowing the reconnection to a previously established connection even if the signer on the other side is offline.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmjs/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
